### PR TITLE
Added subforums

### DIFF
--- a/cache/memcache.go
+++ b/cache/memcache.go
@@ -26,6 +26,7 @@ const (
 	CacheProfileIds int = 8
 	CacheCounts     int = 9
 	CacheOptions    int = 10
+	CacheRootID     int = 11 // Used only by the site type
 )
 
 var (

--- a/cache/memcache.go
+++ b/cache/memcache.go
@@ -27,6 +27,7 @@ const (
 	CacheCounts     int = 9
 	CacheOptions    int = 10
 	CacheRootID     int = 11 // Used only by the site type
+	CacheBreadcrumb int = 12
 )
 
 var (

--- a/controller/microcosm.go
+++ b/controller/microcosm.go
@@ -66,14 +66,23 @@ func (ctl *MicrocosmController) Read(c *models.Context) {
 	// End Authorisation
 
 	// Get Microcosm
-	m, status, err := models.GetMicrocosm(c.Site.ID, itemID, c.Auth.ProfileID)
+	m, status, err := models.GetMicrocosm(
+		c.Site.ID,
+		itemID,
+		c.Auth.ProfileID,
+	)
 	if err != nil {
 		c.RespondWithErrorDetail(err, status)
 		return
 	}
 
 	// Get Items
-	m.Items, status, err = models.GetItems(c.Site.ID, m.ID, c.Auth.ProfileID, c.Request.URL)
+	m.Items, status, err = models.GetItems(
+		c.Site.ID,
+		m.ID,
+		c.Auth.ProfileID,
+		c.Request.URL,
+	)
 	if err != nil {
 		c.RespondWithErrorDetail(err, status)
 		return
@@ -82,9 +91,10 @@ func (ctl *MicrocosmController) Read(c *models.Context) {
 
 	if c.Auth.ProfileID > 0 {
 		// Get watcher status
-		watcherID, sendEmail, sendSms, ignored, status, err := models.GetWatcherAndIgnoreStatus(
-			h.ItemTypes[h.ItemTypeMicrocosm], m.ID, c.Auth.ProfileID,
-		)
+		watcherID, sendEmail, sendSms, ignored, status, err :=
+			models.GetWatcherAndIgnoreStatus(
+				h.ItemTypes[h.ItemTypeMicrocosm], m.ID, c.Auth.ProfileID,
+			)
 		if err != nil {
 			c.RespondWithErrorDetail(err, status)
 			return

--- a/controller/microcosms.go
+++ b/controller/microcosms.go
@@ -107,7 +107,12 @@ func (ctl *MicrocosmsController) ReadMany(c *models.Context) {
 	}
 
 	// Fetch list of microcosms
-	ems, total, pages, status, err := models.GetMicrocosms(c.Site.ID, c.Auth.ProfileID, limit, offset)
+	ems, total, pages, status, err := models.GetRootMicrocosms(
+		c.Site.ID,
+		c.Auth.ProfileID,
+		limit,
+		offset,
+	)
 	if err != nil {
 		c.RespondWithErrorDetail(err, status)
 		return

--- a/controller/microcosms.go
+++ b/controller/microcosms.go
@@ -107,8 +107,12 @@ func (ctl *MicrocosmsController) ReadMany(c *models.Context) {
 	}
 
 	// Fetch list of microcosms
-	ems, total, pages, status, err := models.GetRootMicrocosms(
+	var parentMicrocosmID int64
+	fetchChildren := true
+	ems, total, pages, status, err := models.GetMicrocosms(
 		c.Site.ID,
+		parentMicrocosmID,
+		fetchChildren,
 		c.Auth.ProfileID,
 		limit,
 		offset,

--- a/controller/microcosms.go
+++ b/controller/microcosms.go
@@ -107,12 +107,9 @@ func (ctl *MicrocosmsController) ReadMany(c *models.Context) {
 	}
 
 	// Fetch list of microcosms
-	var parentMicrocosmID int64
-	fetchChildren := true
 	ems, total, pages, status, err := models.GetMicrocosms(
 		c.Site.ID,
-		parentMicrocosmID,
-		fetchChildren,
+		0, // No seed as we are fetching root microcosms
 		c.Auth.ProfileID,
 		limit,
 		offset,

--- a/controller/microcosms.go
+++ b/controller/microcosms.go
@@ -94,47 +94,66 @@ func (ctl *MicrocosmsController) Create(c *models.Context) {
 
 // ReadMany handles GET
 func (ctl *MicrocosmsController) ReadMany(c *models.Context) {
+	rootMicrocosmID := models.GetRootMicrocosmID(c.Site.ID)
 
 	perms := models.GetPermission(
-		models.MakeAuthorisationContext(c, 0, h.ItemTypes[h.ItemTypeSite], c.Site.ID),
+		models.MakeAuthorisationContext(
+			c,
+			rootMicrocosmID,
+			h.ItemTypes[h.ItemTypeMicrocosm],
+			rootMicrocosmID,
+		),
 	)
-
-	// Fetch query string args if any exist
-	limit, offset, status, err := h.GetLimitAndOffset(c.Request.URL.Query())
-	if err != nil {
-		c.RespondWithErrorDetail(err, status)
+	if !perms.CanRead {
+		c.RespondWithErrorMessage(h.NoAuthMessage, http.StatusForbidden)
 		return
 	}
 
-	// Fetch list of microcosms
-	ems, total, pages, status, err := models.GetMicrocosms(
+	// Get Microcosm
+	m, status, err := models.GetMicrocosm(
 		c.Site.ID,
-		0, // No seed as we are fetching root microcosms
+		rootMicrocosmID,
 		c.Auth.ProfileID,
-		limit,
-		offset,
 	)
 	if err != nil {
 		c.RespondWithErrorDetail(err, status)
 		return
 	}
 
-	// Construct the response
-	thisLink := h.GetLinkToThisPage(*c.Request.URL, offset, limit, total)
-	m := models.MicrocosmsType{}
-	m.Microcosms = h.ConstructArray(
-		ems,
-		h.APITypeMicrocosm,
-		total,
-		limit,
-		offset,
-		pages,
+	// Get Items
+	m.Items, status, err = models.GetItems(
+		c.Site.ID,
+		m.ID,
+		c.Auth.ProfileID,
 		c.Request.URL,
 	)
-	m.Meta.Links = []h.LinkType{
-		h.LinkType{Rel: "self", Href: thisLink.String()},
+	if err != nil {
+		c.RespondWithErrorDetail(err, status)
+		return
 	}
 	m.Meta.Permissions = perms
+
+	if c.Auth.ProfileID > 0 {
+		// Get watcher status
+		watcherID, sendEmail, sendSms, ignored, status, err :=
+			models.GetWatcherAndIgnoreStatus(
+				h.ItemTypes[h.ItemTypeMicrocosm], m.ID, c.Auth.ProfileID,
+			)
+		if err != nil {
+			c.RespondWithErrorDetail(err, status)
+			return
+		}
+
+		if ignored {
+			m.Meta.Flags.Ignored = true
+		}
+
+		if watcherID > 0 {
+			m.Meta.Flags.Watched = true
+			m.Meta.Flags.SendEmail = sendEmail
+			m.Meta.Flags.SendSMS = sendSms
+		}
+	}
 
 	c.RespondWithData(m)
 }

--- a/controller/microcosms_tree.go
+++ b/controller/microcosms_tree.go
@@ -1,0 +1,49 @@
+package controller
+
+import (
+	"net/http"
+
+	"github.com/microcosm-cc/microcosm/models"
+)
+
+// MicrocosmsTreeHandler is a web handler
+func MicrocosmsTreeHandler(w http.ResponseWriter, r *http.Request) {
+	c, status, err := models.MakeContext(r, w)
+	if err != nil {
+		c.RespondWithErrorDetail(err, status)
+		return
+	}
+
+	ctl := MicrocosmsTreeController{}
+
+	switch c.GetHTTPMethod() {
+	case "OPTIONS":
+		c.RespondWithOptions([]string{"OPTIONS", "POST", "HEAD", "GET"})
+		return
+	case "HEAD":
+		ctl.ReadMany(c)
+	case "GET":
+		ctl.ReadMany(c)
+	default:
+		c.RespondWithStatus(http.StatusMethodNotAllowed)
+		return
+	}
+}
+
+// MicrocosmsTreeController is a web controller
+type MicrocosmsTreeController struct{}
+
+// ReadMany handles GET
+func (ctl *MicrocosmsTreeController) ReadMany(c *models.Context) {
+	// Get Microcosm Tree
+	m, status, err := models.GetMicrocosmTree(
+		c.Site.ID,
+		c.Auth.ProfileID,
+	)
+	if err != nil {
+		c.RespondWithErrorDetail(err, status)
+		return
+	}
+
+	c.RespondWithData(m)
+}

--- a/db/migrations/20151004160923_parent_microcosms.sql
+++ b/db/migrations/20151004160923_parent_microcosms.sql
@@ -1,0 +1,316 @@
+
+-- +goose Up
+-- SQL in section 'Up' is executed when this migration is applied
+
+ALTER TABLE microcosms ADD COLUMN parent_id bigint REFERENCES microcosms(microcosm_id);
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION update_microcosms_flags()
+  RETURNS trigger AS
+$BODY$
+    BEGIN
+        IF (TG_OP = 'DELETE') THEN
+
+            DELETE
+              FROM flags
+             WHERE item_type_id = 2
+               AND item_id = OLD.microcosm_id;
+
+            RETURN OLD;
+
+        ELSIF (TG_OP = 'UPDATE') THEN
+
+            IF NEW.is_deleted <> OLD.is_deleted OR
+               NEW.is_moderated <> OLD.is_moderated OR
+               NEW.is_sticky <> OLD.is_sticky OR
+               NEW.parent_id <> OLD.parent_id THEN
+
+            -- Microcosms
+            UPDATE flags
+               SET item_is_deleted = NEW.is_deleted
+                  ,item_is_moderated = NEW.is_moderated
+                  ,item_is_sticky = NEW.is_sticky
+                  ,last_modified = COALESCE(NEW.edited, NOW())
+                  ,microcosm_id = NEW.parent_id 
+             WHERE item_type_id = 2
+               AND item_id = NEW.microcosm_id;
+
+            -- Children (items)
+            UPDATE flags
+               SET microcosm_is_deleted = NEW.is_deleted
+                  ,microcosm_is_moderated = NEW.is_moderated
+             WHERE microcosm_id = NEW.microcosm_id;
+
+            END IF;
+
+            RETURN NEW;
+
+        ELSIF (TG_OP = 'INSERT') THEN
+
+            INSERT INTO flags (
+                site_id
+               ,item_type_id
+               ,item_id
+               ,item_is_deleted
+               ,item_is_moderated
+               ,item_is_sticky
+               ,last_modified
+               ,created_by
+               ,microcosm_id
+            )
+            SELECT NEW.site_id
+                  ,2
+                  ,NEW.microcosm_id
+                  ,NEW.is_deleted
+                  ,NEW.is_moderated
+                  ,NEW.is_sticky
+                  ,NEW.created
+                  ,NEW.created_by
+                  ,NEW.parent_id;
+
+            RETURN NEW;
+        END IF;
+        RETURN NULL; -- result is ignored since this is an AFTER trigger
+    END;
+$BODY$
+  LANGUAGE plpgsql VOLATILE
+  COST 100;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION update_microcosms_search_index()
+  RETURNS trigger AS
+$BODY$
+    BEGIN
+        IF (TG_OP = 'DELETE') THEN
+            DELETE
+              FROM search_index
+             WHERE item_type_id = 2
+               AND item_id = OLD.microcosm_id;
+
+            RETURN OLD;
+
+        ELSIF (TG_OP = 'UPDATE') THEN
+            IF NEW.title <> OLD.title OR
+               NEW.description <> OLD.description OR
+               NEW.parent_id <> OLD.parent_id THEN
+        
+                UPDATE search_index
+                   SET title_text = NEW.title
+                      ,title_vector = setweight(to_tsvector(NEW.title), 'A')
+                      ,document_text = NEW.title || ' ' || NEW.description
+                      ,document_vector = setweight(to_tsvector(NEW.title), 'A') || setweight(to_tsvector(NEW.description), 'D')
+                      ,last_modified = NOW()
+                      ,microcosm_id = NEW.parent_id
+                 WHERE item_type_id = 2
+                   AND item_id = NEW.microcosm_id;
+
+            END IF;
+
+            RETURN NEW;
+
+        ELSIF (TG_OP = 'INSERT') THEN
+            INSERT INTO search_index (
+                site_id
+               ,profile_id
+               ,item_type_id
+               ,item_id
+               ,title_text
+
+               ,title_vector
+               ,document_text
+               ,document_vector
+               ,last_modified
+               ,microcosm_id
+            ) VALUES (
+                NEW.site_id
+               ,NEW.created_by
+               ,2
+               ,NEW.microcosm_id
+               ,NEW.title
+
+               ,setweight(to_tsvector(NEW.title), 'A')
+               ,NEW.title || ' ' || NEW.description
+               ,setweight(to_tsvector(NEW.title), 'A') || setweight(to_tsvector(NEW.description), 'D')
+               ,NEW.created
+               ,NEW.parent_id
+            );
+
+            RETURN NEW;
+        END IF;
+        RETURN NULL; -- result is ignored since this is an AFTER trigger
+    END;
+$BODY$
+  LANGUAGE plpgsql VOLATILE
+  COST 100;
+-- +goose StatementEnd
+
+DROP TRIGGER microcosms_flags ON microcosms;
+
+CREATE TRIGGER microcosms_flags
+  AFTER INSERT OR UPDATE OR DELETE
+  ON microcosms
+  FOR EACH ROW
+  EXECUTE PROCEDURE update_microcosms_flags();
+
+DROP TRIGGER microcosms_search_index ON microcosms;
+
+CREATE TRIGGER microcosms_search_index
+  AFTER INSERT OR UPDATE OR DELETE
+  ON microcosms
+  FOR EACH ROW
+  EXECUTE PROCEDURE update_microcosms_search_index();
+
+-- +goose Down
+-- SQL section 'Down' is executed when this migration is rolled back
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION update_microcosms_flags()
+  RETURNS trigger AS
+$BODY$
+    BEGIN
+        IF (TG_OP = 'DELETE') THEN
+
+            DELETE
+              FROM flags
+             WHERE item_type_id = 2
+               AND item_id = OLD.microcosm_id;
+
+            RETURN OLD;
+
+        ELSIF (TG_OP = 'UPDATE') THEN
+
+            IF NEW.is_deleted <> OLD.is_deleted OR
+               NEW.is_moderated <> OLD.is_moderated OR
+               NEW.is_sticky <> OLD.is_sticky THEN
+
+            -- Microcosms
+            UPDATE flags
+               SET item_is_deleted = NEW.is_deleted
+                  ,item_is_moderated = NEW.is_moderated
+                  ,item_is_sticky = NEW.is_sticky
+                  ,last_modified = COALESCE(NEW.edited, NOW())
+             WHERE item_type_id = 2
+               AND item_id = NEW.microcosm_id;
+
+            -- Children (items)
+            UPDATE flags
+               SET microcosm_is_deleted = NEW.is_deleted
+                  ,microcosm_is_moderated = NEW.is_moderated
+             WHERE microcosm_id = NEW.microcosm_id;
+
+            END IF;
+
+            RETURN NEW;
+
+        ELSIF (TG_OP = 'INSERT') THEN
+
+            INSERT INTO flags (
+                site_id
+               ,item_type_id
+               ,item_id
+               ,item_is_deleted
+               ,item_is_moderated
+               ,item_is_sticky
+               ,last_modified
+               ,created_by
+            )
+            SELECT NEW.site_id
+                  ,2
+                  ,NEW.microcosm_id
+                  ,NEW.is_deleted
+                  ,NEW.is_moderated
+                  ,NEW.is_sticky
+                  ,NEW.created
+                  ,NEW.created_by;
+
+            RETURN NEW;
+        END IF;
+        RETURN NULL; -- result is ignored since this is an AFTER trigger
+    END;
+$BODY$
+  LANGUAGE plpgsql VOLATILE
+  COST 100;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION update_microcosms_search_index()
+  RETURNS trigger AS
+$BODY$
+    BEGIN
+        IF (TG_OP = 'DELETE') THEN
+            DELETE
+              FROM search_index
+             WHERE item_type_id = 2
+               AND item_id = OLD.microcosm_id;
+
+            RETURN OLD;
+
+        ELSIF (TG_OP = 'UPDATE') THEN
+            IF NEW.title <> OLD.title OR NEW.description <> OLD.description THEN
+        
+                UPDATE search_index
+                   SET title_text = NEW.title
+                      ,title_vector = setweight(to_tsvector(NEW.title), 'A')
+                      ,document_text = NEW.title || ' ' || NEW.description
+                      ,document_vector = setweight(to_tsvector(NEW.title), 'A') || setweight(to_tsvector(NEW.description), 'D')
+                      ,last_modified = NOW()
+                 WHERE item_type_id = 2
+                   AND item_id = NEW.microcosm_id;
+
+            END IF;
+
+            RETURN NEW;
+
+        ELSIF (TG_OP = 'INSERT') THEN
+            INSERT INTO search_index (
+                site_id
+               ,profile_id
+               ,item_type_id
+               ,item_id
+               ,title_text
+
+               ,title_vector
+               ,document_text
+               ,document_vector
+               ,last_modified
+            ) VALUES (
+                NEW.site_id
+               ,NEW.created_by
+               ,2
+               ,NEW.microcosm_id
+               ,NEW.title
+
+               ,setweight(to_tsvector(NEW.title), 'A')
+               ,NEW.title || ' ' || NEW.description
+               ,setweight(to_tsvector(NEW.title), 'A') || setweight(to_tsvector(NEW.description), 'D')
+               ,NEW.created
+            );
+
+            RETURN NEW;
+        END IF;
+        RETURN NULL; -- result is ignored since this is an AFTER trigger
+    END;
+$BODY$
+  LANGUAGE plpgsql VOLATILE
+  COST 100;
+-- +goose StatementEnd
+
+DROP TRIGGER microcosms_flags ON microcosms;
+
+CREATE TRIGGER microcosms_flags
+  AFTER INSERT OR UPDATE OR DELETE
+  ON microcosms
+  FOR EACH ROW
+  EXECUTE PROCEDURE update_microcosms_flags();
+
+DROP TRIGGER microcosms_search_index ON microcosms;
+
+CREATE TRIGGER microcosms_search_index
+  AFTER INSERT OR UPDATE OR DELETE
+  ON microcosms
+  FOR EACH ROW
+  EXECUTE PROCEDURE update_microcosms_search_index();
+
+ALTER TABLE microcosms DROP CONSTRAINT microcosms_parent_id_fkey;
+ALTER TABLE microcosms DROP COLUMN parent_id;

--- a/db/migrations/20151007221027_microcosm_item_types.sql
+++ b/db/migrations/20151007221027_microcosm_item_types.sql
@@ -1,0 +1,22 @@
+
+-- +goose Up
+-- SQL in section 'Up' is executed when this migration is applied
+
+ALTER TABLE microcosms
+  ADD COLUMN item_types bigint[] NOT NULL DEFAULT '{2,6,9}';
+COMMENT ON COLUMN microcosms.item_types IS 'Array of item_types.item_type_id that are allowed to be posted in this microcosm.
+
+Allowing just item_type_id = 2 would mean that a Microcosm is just a category as it could contain no content.
+
+Allowing 6,9 would mean that it is not able to have child forums and is a leaf forum.
+
+Allowing 9 would mean that it can only contain events.
+
+2,6,9 would currently allow everything.';
+
+
+-- +goose Down
+-- SQL section 'Down' is executed when this migration is rolled back
+
+ALTER TABLE microcosms
+  DROP COLUMN item_types;

--- a/db/migrations/20151011200812_microcosm_paths.sql
+++ b/db/migrations/20151011200812_microcosm_paths.sql
@@ -1,0 +1,32 @@
+
+-- +goose Up
+-- SQL in section 'Up' is executed when this migration is applied
+
+ALTER TABLE microcosms ADD COLUMN path ltree;
+
+CREATE INDEX microcosms_path_gist_idx ON microcosms USING GIST(path);
+CREATE INDEX microcosms_path_idx ON microcosms USING btree(path);
+
+WITH RECURSIVE parent_microcosms AS (
+    SELECT microcosm_id
+          ,CAST(microcosm_id AS VARCHAR) AS path
+      FROM microcosms
+     WHERE parent_id IS NULL
+     UNION ALL
+    SELECT c.microcosm_id
+          ,p.path || '.' || CAST(c.microcosm_id AS VARCHAR)
+      FROM microcosms c
+      JOIN parent_microcosms p ON c.parent_id = p.microcosm_id
+)
+UPDATE microcosms m
+   SET path = CAST(p.path AS ltree)
+  FROM parent_microcosms p
+ WHERE m.microcosm_id = p.microcosm_id;
+
+-- +goose Down
+-- SQL section 'Down' is executed when this migration is rolled back
+
+DROP INDEX microcosms_path_gist_idx;
+DROP INDEX microcosms_path_idx;
+
+ALTER TABLE microcosms DROP COLUMN path;

--- a/db/migrations/20151022232529_root_microcosms.sql
+++ b/db/migrations/20151022232529_root_microcosms.sql
@@ -75,6 +75,7 @@ UPDATE roles r
    SET microcosm_id = m.microcosm_id
   FROM microcosms m
  WHERE r.site_id = m.site_id
+   AND r.microcosm_id IS NULL
    AND m.parent_id IS NULL;
 
 -- +goose StatementBegin

--- a/db/migrations/20151022232529_root_microcosms.sql
+++ b/db/migrations/20151022232529_root_microcosms.sql
@@ -1,0 +1,651 @@
+
+-- +goose Up
+-- SQL in section 'Up' is executed when this migration is applied
+
+-- Create root microcosms
+INSERT INTO microcosms (
+    site_id, visibility, title, description, created,
+    created_by, owned_by, item_types
+)
+SELECT site_id
+      ,'public'
+      ,'Forums'
+      ,description
+      ,created
+      ,created_by
+      ,owned_by
+      ,'{2,6,9}'::bigint[]
+  FROM sites;
+
+-- Assign existing microcosms to root
+UPDATE microcosms m2
+   SET parent_id = r.microcosm_id
+  FROM (
+           SELECT s.site_id
+                 ,m.microcosm_id
+             FROM sites s
+                 ,microcosms m
+            WHERE s.site_id = m.site_id
+              AND s.created = m.created
+              AND m.parent_id IS NULL
+       ) AS r
+ WHERE m2.microcosm_id != r.microcosm_id
+   AND m2.site_id = r.site_id
+   AND m2.parent_id IS NULL;
+
+-- Update all paths
+WITH RECURSIVE parent_microcosms AS (
+    SELECT microcosm_id
+          ,CAST(microcosm_id AS VARCHAR) AS path
+      FROM microcosms
+     WHERE parent_id IS NULL
+     UNION ALL
+    SELECT c.microcosm_id
+          ,p.path || '.' || CAST(c.microcosm_id AS VARCHAR)
+      FROM microcosms c
+      JOIN parent_microcosms p ON c.parent_id = p.microcosm_id
+)
+UPDATE microcosms m
+   SET path = CAST(p.path AS ltree)
+  FROM parent_microcosms p
+ WHERE m.microcosm_id = p.microcosm_id
+   AND (
+           m.path IS NULL
+        OR CAST(m.path AS VARCHAR) <> p.path
+       );
+
+-- update search indexes
+UPDATE search_index si
+   SET microcosm_id = m.parent_id
+  FROM microcosms m
+ WHERE si.item_type_id = 2
+   AND si.item_id = m.microcosm_id
+   AND m.parent_id IS NOT NULL;
+
+-- update flags
+UPDATE flags f
+   SET microcosm_id = m.parent_id
+  FROM microcosms m
+ WHERE f.item_type_id = 2
+   AND f.item_id = m.microcosm_id
+   AND m.parent_id IS NOT NULL;
+
+-- assign default roles to root microcosms
+UPDATE roles r
+   SET microcosm_id = m.microcosm_id
+  FROM microcosms m
+ WHERE r.site_id = m.site_id
+   AND m.parent_id IS NULL;
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION create_owned_site(
+    IN in_title CHARACTER VARYING,
+    IN in_subdomain_key CHARACTER VARYING,
+    IN in_theme_id BIGINT,
+    IN in_user_id BIGINT,
+    IN in_profile_name CHARACTER VARYING,
+    IN in_avatar_id BIGINT,
+    IN in_avatar_url CHARACTER VARYING,
+    IN in_domain CHARACTER VARYING DEFAULT NULL::CHARACTER VARYING,
+    IN in_description TEXT DEFAULT NULL::TEXT,
+    IN in_logo_url CHARACTER VARYING DEFAULT NULL::CHARACTER VARYING,
+    IN in_background_url CHARACTER VARYING DEFAULT NULL::CHARACTER VARYING,
+    IN in_background_position CHARACTER VARYING DEFAULT NULL::CHARACTER VARYING,
+    IN in_background_color CHARACTER VARYING DEFAULT NULL::CHARACTER VARYING,
+    IN in_link_color CHARACTER VARYING DEFAULT NULL::CHARACTER VARYING,
+    IN in_ga_web_property_id CHARACTER VARYING DEFAULT NULL::CHARACTER VARYING)
+  RETURNS TABLE(new_site_id BIGINT, new_profile_id BIGINT) AS
+$BODY$
+DECLARE
+BEGIN
+
+DROP TABLE IF EXISTS new_ids;
+
+CREATE TEMP TABLE new_ids (
+    profile_id BIGINT NOT NULL,
+    site_id BIGINT NOT NULL,
+    role_id BIGINT NOT NULL,
+    criteria_id BIGINT NOT NULL,
+    microcosm_id BIGINT NOT NULL,
+    now TIMESTAMP WITHOUT TIME ZONE NOT NULL
+) ON COMMIT DROP;
+
+INSERT INTO new_ids (
+    profile_id, site_id, role_id, criteria_id, microcosm_id
+)
+SELECT NEXTVAL('profiles_profile_id_seq'),
+       NEXTVAL('sites_site_id_seq'),
+       NEXTVAL('roles_role_id_seq'),
+       NEXTVAL('criteria_criteria_id_seq'),
+       NEXTVAL('microcosm_microcosm_id_seq'),
+       NOW();
+
+INSERT INTO sites (
+    site_id, title, description, subdomain_key, domain,
+    created, created_by, owned_by, theme_id, logo_url,
+    background_url, background_position, background_color, link_color, ga_web_property_id
+)
+SELECT site_id, in_title, in_description, in_subdomain_key, in_domain,
+       now, profile_id, profile_id, in_theme_id, in_logo_url,
+       in_background_url, in_background_position, in_background_color, in_link_color, in_ga_web_property_id
+  FROM new_ids;
+
+INSERT INTO profiles (
+    profile_id, site_id, user_id, profile_name, created,
+    last_active, avatar_id, avatar_url
+)
+SELECT profile_id, site_id, in_user_id, in_profile_name, now,
+       now, in_avatar_id, in_avatar_url
+  FROM new_ids;
+
+INSERT INTO microcosms (
+    microcosm_id, site_id, visibility, title, description,
+    created, created_by, owned_by, item_types
+)
+SELECT microcosm_id, site_id, 'public', 'Forums', in_description,
+       now, profile_id, profile_id, '{2,6,9}'::BIGINT[]
+  FROM new_ids;
+
+INSERT INTO roles (
+    role_id, title, site_id, microcosm_id, created,
+    created_by, is_moderator_role, is_banned_role, include_guests, can_read,
+    can_create, can_update, can_delete, can_close_own, can_open_own,
+    can_read_others
+)
+SELECT role_id, 'Guests', site_id, microcosm_id, now,
+       NULL, false, false, true, true,
+       false, false, false, false, false,
+       false
+  FROM new_ids;
+
+UPDATE new_ids SET role_id = NEXTVAL('roles_role_id_seq');
+INSERT INTO roles (
+    role_id, title, site_id, microcosm_id, created,
+    created_by, is_moderator_role, is_banned_role, include_guests, can_read,
+    can_create, can_update, can_delete, can_close_own, can_open_own,
+    can_read_others, include_users
+)
+SELECT role_id, 'Members', site_id, microcosm_id, now,
+       NULL, false, false, false, true,
+       true, false, false, true, false,
+       true, true
+  FROM new_ids;
+
+UPDATE new_ids SET role_id = NEXTVAL('roles_role_id_seq');
+INSERT INTO roles (
+    role_id, title, site_id, microcosm_id, created,
+    created_by, is_moderator_role, is_banned_role, include_guests, can_read,
+    can_create, can_update, can_delete, can_close_own, can_open_own,
+    can_read_others
+) SELECT
+    role_id, 'Banned', site_id, microcosm_id, now,
+    NULL, false, true, false, false,
+    false, false, false, false, false,
+    false
+FROM new_ids;
+
+INSERT INTO site_options (
+    site_id, send_email, send_sms, only_admins_can_create_microcosms
+)
+SELECT site_id, true, false, true
+FROM new_ids;
+
+-- To get around the chicken and egg problem of foreign keys
+-- the trigger to update flags used the lowest valid profile_id
+-- which we now correct.
+UPDATE roles r
+   SET created_by = n.profile_id
+  FROM new_ids n
+ WHERE r.site_id = n.site_id;
+
+UPDATE flags f
+   SET created_by = n.profile_id
+  FROM new_ids n
+ WHERE f.item_type_id = 1
+   AND f.item_id = n.site_id;
+
+RETURN QUERY SELECT site_id, profile_id FROM new_ids;
+END;
+$BODY$
+  LANGUAGE plpgsql VOLATILE
+  COST 100
+  ROWS 1000;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION development.get_microcosm_roles(
+    insiteid bigint DEFAULT 0,
+    inmicrocosmid bigint DEFAULT 0)
+  RETURNS SETOF bigint AS
+$BODY$
+DECLARE
+    l_root_id BIGINT;
+    l_parent_id bigint;
+BEGIN
+    -- Get the id of the root microcosm as this holds our default roles
+    l_root_id := (
+        SELECT microcosm_id
+          FROM microcosms
+         WHERE site_id = insiteid
+           AND parent_id IS NULL
+    );
+    -- Are there custom roles against this microcosm?
+    IF EXISTS (
+        SELECT 1
+          FROM roles
+         WHERE site_id = insiteid
+           AND microcosm_id = inmicrocosmid
+           AND microcosm_id != l_root_id
+           AND is_banned_role IS NOT TRUE -- override
+           AND is_moderator_role IS NOT TRUE
+    ) THEN
+        -- custom + special + default_special
+        RETURN QUERY
+            SELECT role_id
+              FROM roles
+             WHERE site_id = insiteid
+               AND (
+                       -- overrides + special
+                       microcosm_id = inmicrocosmid
+                    OR (
+                           -- default_special
+                           microcosm_id = l_root_id
+                       AND (
+                               is_banned_role IS TRUE
+                            OR is_moderator_role IS TRUE
+                           )
+                       )
+                   );
+    ELSE
+        l_parent_id := (
+            SELECT parent_id
+              FROM microcosms
+             WHERE microcosm_id = inmicrocosmid
+        );
+        IF l_parent_id IS NOT NULL THEN
+            -- recursion rocks, walk the parent microcosms to find the first one
+            -- that has custom roles
+            RETURN QUERY
+                SELECT *
+                  FROM get_microcosm_roles(insiteid, l_parent_id);
+        ELSE
+            IF EXISTS (
+                SELECT 1
+                  FROM roles
+                 WHERE site_id = insiteid
+                   AND microcosm_id = inmicrocosmid
+                   AND (
+                           is_banned_role IS TRUE -- special
+                        OR is_moderator_role IS TRUE
+                       )
+            ) THEN
+                -- special + defaults + default_special
+                RETURN QUERY
+                    SELECT role_id
+                      FROM roles
+                     WHERE site_id = insiteid
+                       AND (
+                               -- defaults
+                               microcosm_id = l_root_id
+                            OR (   -- special
+                                   microcosm_id = inmicrocosmid
+                               AND (
+                                       is_banned_role IS TRUE
+                                    OR is_moderator_role IS TRUE
+                                   )
+                               )
+                           );
+            ELSE
+                -- defaults + default_special
+                RETURN QUERY
+                    SELECT role_id
+                      FROM roles
+                     WHERE site_id = insiteid
+                       AND microcosm_id = l_root_id;
+            END IF;
+        END IF;
+    END IF;
+END;
+$BODY$
+  LANGUAGE plpgsql VOLATILE
+  COST 100
+  ROWS 1;
+-- +goose StatementEnd
+
+-- +goose Down
+-- SQL section 'Down' is executed when this migration is rolled back
+
+-- There is no effective downgrade from this as we will not perform a downgrade
+-- that could be destructive, and this potentially would be (we'd need to nuke
+-- any content in the root microcosm that wasn't a microcosm)
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION create_owned_site(
+    IN in_title character varying,
+    IN in_subdomain_key character varying,
+    IN in_theme_id bigint,
+    IN in_user_id bigint,
+    IN in_profile_name character varying,
+    IN in_avatar_id bigint,
+    IN in_avatar_url character varying,
+    IN in_domain character varying DEFAULT NULL::character varying,
+    IN in_description text DEFAULT NULL::text,
+    IN in_logo_url character varying DEFAULT NULL::character varying,
+    IN in_background_url character varying DEFAULT NULL::character varying,
+    IN in_background_position character varying DEFAULT NULL::character varying,
+    IN in_background_color character varying DEFAULT NULL::character varying,
+    IN in_link_color character varying DEFAULT NULL::character varying,
+    IN in_ga_web_property_id character varying DEFAULT NULL::character varying)
+  RETURNS TABLE(new_site_id bigint, new_profile_id bigint) AS
+$BODY$
+DECLARE
+BEGIN
+
+DROP TABLE IF EXISTS new_ids;
+
+CREATE TEMP TABLE new_ids (
+    profile_id bigint NOT NULL,
+    site_id bigint NOT NULL,
+    role_id bigint NOT NULL,
+    criteria_id bigint NOT NULL
+) ON COMMIT DROP;
+
+INSERT INTO new_ids (profile_id, site_id, role_id, criteria_id)
+SELECT NEXTVAL('profiles_profile_id_seq'),
+       NEXTVAL('sites_site_id_seq'),
+       NEXTVAL('roles_role_id_seq'),
+       NEXTVAL('criteria_criteria_id_seq');
+
+INSERT INTO sites (
+    site_id,
+    title,
+    description,
+    subdomain_key,
+    domain,
+    
+    created,
+    created_by,
+    owned_by,
+    theme_id,
+    logo_url,
+    
+    background_url,
+    background_position,
+	background_color,
+	link_color,
+    ga_web_property_id
+) SELECT 
+    site_id,
+    in_title,
+    in_description,
+    in_subdomain_key,
+    in_domain,
+    
+    NOW(),
+    profile_id,
+    profile_id,
+    in_theme_id,
+    in_logo_url,
+    
+    in_background_url,
+    in_background_position,
+	in_background_color,
+	in_link_color,
+    in_ga_web_property_id
+FROM new_ids;
+
+INSERT INTO profiles (
+    profile_id,
+    site_id,
+    user_id,
+    profile_name,
+    created,
+
+    last_active,
+    avatar_id,
+    avatar_url
+) SELECT
+    profile_id,
+    site_id,
+    in_user_id,
+    in_profile_name,
+    NOW(),
+
+    NOW(),
+    in_avatar_id,
+    in_avatar_url
+FROM new_ids;
+
+INSERT INTO roles (
+    role_id,
+    title,
+    site_id,
+    microcosm_id,
+    created,
+
+    created_by,
+    is_moderator_role,
+    is_banned_role,
+    include_guests,
+    can_read,
+
+    can_create,
+    can_update,
+    can_delete,
+    can_close_own,
+    can_open_own,
+
+    can_read_others
+) SELECT 
+    role_id,
+    'Guests',
+    site_id,
+    NULL,
+    NOW(),
+
+    NULL,
+    false,
+    false,
+    true,
+    true,
+
+    false,
+    false,
+    false,
+    false,
+    false,
+
+    false
+FROM new_ids;
+
+UPDATE new_ids SET role_id = NEXTVAL('roles_role_id_seq');
+INSERT INTO roles (
+    role_id,
+    title,
+    site_id,
+    microcosm_id,
+    created,
+
+    created_by,
+    is_moderator_role,
+    is_banned_role,
+    include_guests,
+    can_read,
+
+    can_create,
+    can_update,
+    can_delete,
+    can_close_own,
+    can_open_own,
+
+    can_read_others,
+    include_users
+) SELECT
+    role_id,
+    'Members',
+    site_id,
+    NULL,
+    NOW(),
+
+    NULL,
+    false,
+    false,
+    false,
+    true,
+
+    true,
+    false,
+    false,
+    true,
+    false,
+
+    true,
+    TRUE
+FROM new_ids;
+
+UPDATE new_ids SET role_id = NEXTVAL('roles_role_id_seq');
+INSERT INTO roles (
+    role_id,
+    title,
+    site_id,
+    microcosm_id,
+    created,
+
+    created_by,
+    is_moderator_role,
+    is_banned_role,
+    include_guests,
+    can_read,
+
+    can_create,
+    can_update,
+    can_delete,
+    can_close_own,
+    can_open_own,
+
+    can_read_others
+) SELECT
+    role_id,
+    'Banned',
+    site_id,
+    NULL,
+    NOW(),
+
+    NULL,
+    false,
+    true,
+    false,
+    false,
+
+    false,
+    false,
+    false,
+    false,
+    false,
+
+    false
+FROM new_ids;
+
+INSERT INTO site_options (
+    site_id,
+    send_email,
+    send_sms,
+    only_admins_can_create_microcosms
+)
+SELECT
+    site_id,
+    true,
+    false,
+    true
+FROM new_ids;
+
+-- To get around the chicken and egg problem of foreign keys
+-- the trigger to update flags used the lowest valid profile_id
+-- which we now correct.
+UPDATE roles r
+   SET created_by = n.profile_id
+  FROM new_ids n
+ WHERE r.site_id = n.site_id;
+
+UPDATE flags f
+   SET created_by = n.profile_id
+  FROM new_ids n
+ WHERE f.item_type_id = 1
+   AND f.item_id = n.site_id;
+
+RETURN QUERY SELECT site_id, profile_id FROM new_ids;
+END;
+$BODY$
+  LANGUAGE plpgsql VOLATILE
+  COST 100
+  ROWS 1000;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION development.get_microcosm_roles(
+    insiteid bigint DEFAULT 0,
+    inmicrocosmid bigint DEFAULT 0)
+  RETURNS SETOF bigint AS
+$BODY$
+BEGIN
+
+    IF EXISTS (SELECT 1
+              FROM roles
+             WHERE site_id = insiteid
+               AND microcosm_id = inmicrocosmid
+               AND is_banned_role IS NOT TRUE -- override
+               AND is_moderator_role IS NOT TRUE
+           ) THEN
+  -- overrides + special + default_special
+        RETURN QUERY
+            SELECT role_id
+              FROM roles
+             WHERE site_id = insiteid
+               AND (
+         -- overrides and special
+         microcosm_id = inmicrocosmid
+      OR ( -- default_special
+             microcosm_id IS NULL
+         AND (   is_banned_role IS TRUE
+        OR is_moderator_role IS TRUE)
+         )
+                   );
+    ELSE
+      IF EXISTS (SELECT 1
+          FROM roles
+         WHERE site_id = insiteid
+           AND microcosm_id = inmicrocosmid
+           AND (   is_banned_role IS TRUE -- special
+          OR is_moderator_role IS TRUE)
+       ) THEN
+
+    -- special + defaults + default_special
+    RETURN QUERY
+        SELECT role_id
+          FROM roles
+         WHERE site_id = insiteid
+           AND (
+           -- defaults
+           microcosm_id IS NULL
+        OR ( -- special
+               microcosm_id = inmicrocosmid
+           AND (   is_banned_role IS TRUE
+          OR is_moderator_role IS TRUE)
+           )
+         );
+
+      ELSE
+    -- defaults + default_special
+    RETURN QUERY
+        SELECT role_id
+          FROM roles
+         WHERE site_id = insiteid
+           AND microcosm_id IS NULL;
+      END IF;
+    END IF;
+END;
+$BODY$
+  LANGUAGE plpgsql VOLATILE
+  COST 100
+  ROWS 1;
+-- +goose StatementEnd

--- a/db/migrations/20151024195318_ignores.sql
+++ b/db/migrations/20151024195318_ignores.sql
@@ -1,0 +1,29 @@
+
+-- +goose Up
+-- SQL in section 'Up' is executed when this migration is applied
+
+CREATE OR REPLACE VIEW ignores_expanded AS
+SELECT *
+  FROM ignores
+ WHERE item_type_id <> 2
+ UNION
+SELECT im.profile_id
+      ,2
+      ,o.microcosm_id
+ FROM (
+          SELECT i.*
+                ,m.path
+            FROM ignores i
+                 JOIN microcosms m ON i.item_type_id = 2 AND m.microcosm_id = i.item_id
+           WHERE i.item_type_id = 2
+      ) AS im
+      JOIN microcosms o ON o.path <@ im.path;
+
+COMMENT ON VIEW ignores_expanded
+  IS 'Expands ignored microcosms to also ignore child microcosms of an ignored microcosm';
+
+
+-- +goose Down
+-- SQL section 'Down' is executed when this migration is rolled back
+
+DROP VIEW ignores_expanded;

--- a/db/migrations/20151112231934_is_unread.sql
+++ b/db/migrations/20151112231934_is_unread.sql
@@ -1,0 +1,677 @@
+
+-- +goose Up
+-- SQL in section 'Up' is executed when this migration is applied
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION has_unread(
+    in_item_type_id bigint DEFAULT 0,
+    in_item_id bigint DEFAULT 0,
+    in_profile_id bigint DEFAULT 0)
+  RETURNS boolean AS
+$BODY$
+DECLARE
+BEGIN
+
+    IF in_profile_id = 0 THEN
+        RETURN false;
+    END IF;
+
+    CASE in_item_type_id
+    WHEN 1 THEN -- site
+    WHEN 2 THEN -- microcosm
+
+        -- Check child forums should they exist
+        IF (SELECT COALESCE(BOOL_OR(has_unread(2, m.microcosm_id, in_profile_id)), FALSE)
+              FROM microcosms m
+              LEFT JOIN permissions_cache p ON p.site_id = m.site_id
+                                           AND p.item_type_id = 2
+                                           AND p.item_id = m.microcosm_id
+                                           AND p.profile_id = in_profile_id
+                   LEFT JOIN ignores_expanded i ON i.profile_id = in_profile_id
+                                               AND i.item_type_id = 2
+                                               AND i.item_id = m.microcosm_id
+             WHERE m.parent_id = in_item_id
+               AND m.is_deleted IS NOT TRUE
+               AND m.is_moderated IS NOT TRUE
+               AND i.profile_id IS NULL
+               AND (
+                       (p.can_read IS NOT NULL AND p.can_read IS TRUE)
+                    OR (get_effective_permissions(m.site_id,m.microcosm_id,2,m.microcosm_id,in_profile_id)).can_read IS TRUE
+                   )) THEN
+            RETURN TRUE;
+        END IF;
+
+        -- Check the last read of the microcosm against the read time
+        IF NOT (SELECT COALESCE(
+                (
+                    SELECT last_modified
+                      FROM flags
+                     WHERE microcosm_id = in_item_id
+                       AND item_type_id IN (6, 9)
+                       AND NOT item_is_deleted
+                       AND NOT item_is_moderated
+                       AND last_modified > (
+                               SELECT read
+                                 FROM read
+                                WHERE profile_id = in_profile_id
+                                  AND item_type_id = in_item_type_id
+                                  AND item_id = in_item_id
+                           )
+                     ORDER BY last_modified DESC
+                     LIMIT 1
+                ) > (
+                    SELECT read
+                      FROM read
+                     WHERE profile_id = in_profile_id
+                       AND item_type_id = in_item_type_id
+                       AND item_id = in_item_id
+                ), true)) THEN
+            RETURN false;
+        END IF;
+
+        -- We don't have a recent last_read indicator, and need to call
+        -- has_unread for items... but if we do have an old read row for
+        -- the microcosm then we only need to check the items since that
+        -- time.
+        IF (SELECT COUNT(*)
+              FROM read
+             WHERE profile_id = in_profile_id
+               AND item_type_id = in_item_type_id
+               AND item_id = in_item_id ) > 0 THEN
+
+            RETURN (SELECT EXISTS(
+                        SELECT 1
+                          FROM flags
+                         WHERE microcosm_id = in_item_id
+                           AND item_type_id IN (6, 9)
+                           AND NOT item_is_deleted
+                           AND NOT item_is_moderated
+                           AND last_modified > (
+                                   SELECT read
+                                     FROM read
+                                    WHERE profile_id = in_profile_id
+                                      AND item_type_id = in_item_type_id
+                                      AND item_id = in_item_id
+                               )
+                           AND has_unread(item_type_id, item_id, in_profile_id)
+                         ORDER BY last_modified DESC
+                   ));
+
+        ELSE
+
+            -- The really slow way, iterate every item until we hit something unread
+            RETURN (SELECT EXISTS(
+                        SELECT 1
+                          FROM flags
+                         WHERE microcosm_id = in_item_id
+                           AND item_type_id IN (6, 9)
+                           AND NOT item_is_deleted
+                           AND NOT item_is_moderated
+                           AND has_unread(item_type_id, item_id, in_profile_id)
+                         ORDER BY last_modified DESC
+                   ));
+        END IF;
+
+    WHEN 3 THEN -- profile
+    WHEN 4 THEN -- comment
+    WHEN 5 THEN -- huddle
+
+        -- Check the last read of all huddles against the read time
+        IF NOT (SELECT COALESCE(
+                (
+                    SELECT last_modified
+                      FROM flags
+                     WHERE item_type_id = 5
+                       AND item_id = in_item_id
+                       AND NOT item_is_deleted
+                       AND NOT item_is_moderated
+                       AND last_modified > (
+                               SELECT read
+                                 FROM read
+                                WHERE profile_id = in_profile_id
+                                  AND item_type_id = 5
+                                  AND item_id = 0
+                           )
+                ) > (
+                    SELECT read
+                      FROM read
+                     WHERE profile_id = in_profile_id
+                       AND item_type_id = 5
+                       AND item_id = 0
+                ), true)) THEN
+            RETURN false;
+        END IF;
+
+
+        -- We don't have a recent last_read indicator, and need to call
+        -- has_unread for items... but if we do have an old read row for
+        -- all huddles then we only need to check the items since that
+        -- time.
+        IF (SELECT EXISTS(
+            SELECT 1
+              FROM read
+             WHERE profile_id = in_profile_id
+               AND item_type_id = 5
+               AND item_id = 0 )) THEN
+
+            RETURN (SELECT EXISTS(
+                       SELECT 1
+                         FROM (            
+                        SELECT COALESCE(f.last_modified > GREATEST(MAX(r.read), r2.read), true) AS unread
+                          FROM flags f
+                               LEFT JOIN read r ON r.item_type_id = 5
+                                               AND r.item_id = in_item_id
+                                               AND r.profile_id = in_profile_id
+                              ,(
+                                   SELECT read
+                                     FROM read
+                                    WHERE profile_id = in_profile_Id
+                                      AND item_type_id = 5
+                                      AND item_id = 0
+                               ) r2
+                         WHERE f.item_type_id = 5
+                           AND f.item_id = in_item_id
+                           AND f.item_is_deleted IS NOT TRUE
+                           AND f.item_is_moderated IS NOT TRUE
+                         GROUP BY f.last_modified, r2.read
+                               ) as u
+                         WHERE unread
+                   ));
+
+        ELSE
+
+            -- The really slow way, iterate every item until we hit something unread
+            RETURN (SELECT EXISTS(
+                        SELECT 1
+                          FROM (
+                                SELECT COALESCE(i.last_modified > MAX(r.read), true) AS unread
+                                  FROM flags i
+                                       LEFT JOIN read r ON r.item_type_id = in_item_type_id
+                                                       AND r.item_id = in_item_id
+                                                       AND r.profile_id = in_profile_id
+                                 WHERE i.item_type_id = in_item_type_id
+                                   AND i.item_id = in_item_id
+                                 GROUP BY r.read, i.last_modified
+                               ) AS u
+                         WHERE unread
+                   ));
+
+        END IF;
+
+    WHEN 6 THEN -- conversation
+
+        RETURN COUNT(*) > 0 AS has_unread
+          FROM (
+                SELECT COALESCE(i.last_modified > r.read, true) AS unread
+                  FROM flags i
+                       LEFT JOIN "read" r
+                         ON (
+                                (r.item_type_id = i.item_type_id AND r.item_id = i.item_id) 
+                             OR (r.item_type_id = 2 AND r.item_id = i.microcosm_id)
+                            )
+                        AND r.profile_id = in_profile_id
+                 WHERE i.item_type_id = in_item_type_id
+                   AND i.item_id = in_item_id
+                 ORDER BY r.read DESC
+                 LIMIT 1
+               ) AS u
+         WHERE unread;
+
+    WHEN 7 THEN -- poll
+
+        RETURN COUNT(*) > 0 AS has_unread
+          FROM (
+                SELECT COALESCE(i.last_modified > r.read, true) AS unread
+                  FROM flags i
+                       LEFT JOIN "read" r
+                         ON (
+                                (r.item_type_id = i.item_type_id AND r.item_id = i.item_id) 
+                             OR (r.item_type_id = 2 AND r.item_id = i.microcosm_id)
+                            )
+                        AND r.profile_id = in_profile_id
+                 WHERE i.item_type_id = in_item_type_id
+                   AND i.item_id = in_item_id
+                 ORDER BY r.read DESC
+                 LIMIT 1
+               ) AS u
+         WHERE unread;
+
+    WHEN 8 THEN -- article
+
+        RETURN COUNT(*) > 0 AS has_unread
+          FROM (
+                SELECT COALESCE(i.last_modified > r.read, true) AS unread
+                  FROM flags i
+                       LEFT JOIN "read" r
+                         ON (
+                                (r.item_type_id = i.item_type_id AND r.item_id = i.item_id) 
+                             OR (r.item_type_id = 2 AND r.item_id = i.microcosm_id)
+                            )
+                        AND r.profile_id = in_profile_id
+                 WHERE i.item_type_id = in_item_type_id
+                   AND i.item_id = in_item_id
+                 ORDER BY r.read DESC
+                 LIMIT 1
+               ) AS u
+         WHERE unread;
+
+    WHEN 9 THEN -- event
+
+        RETURN COUNT(*) > 0 AS has_unread
+          FROM (
+                SELECT COALESCE(i.last_modified > r.read, true) AS unread
+                  FROM flags i
+                       LEFT JOIN "read" r
+                         ON (
+                                (r.item_type_id = i.item_type_id AND r.item_id = i.item_id) 
+                             OR (r.item_type_id = 2 AND r.item_id = i.microcosm_id)
+                            )
+                        AND r.profile_id = in_profile_id
+                 WHERE i.item_type_id = in_item_type_id
+                   AND i.item_id = in_item_id
+                 ORDER BY r.read DESC
+                 LIMIT 1
+               ) AS u
+         WHERE unread;
+
+    WHEN 10 THEN -- question
+
+        RETURN COUNT(*) > 0 AS has_unread
+          FROM (
+                SELECT COALESCE(i.last_modified > r.read, true) AS unread
+                  FROM flags i
+                       LEFT JOIN "read" r
+                         ON (
+                                (r.item_type_id = i.item_type_id AND r.item_id = i.item_id) 
+                             OR (r.item_type_id = 2 AND r.item_id = i.microcosm_id)
+                            )
+                        AND r.profile_id = in_profile_id
+                 WHERE i.item_type_id = in_item_type_id
+                   AND i.item_id = in_item_id
+                 ORDER BY r.read DESC
+                 LIMIT 1
+               ) AS u
+         WHERE unread;
+
+    WHEN 11 THEN -- classified
+
+        RETURN COUNT(*) > 0 AS has_unread
+          FROM (
+                SELECT COALESCE(i.last_modified > r.read, true) AS unread
+                  FROM flags i
+                       LEFT JOIN "read" r
+                         ON (
+                                (r.item_type_id = i.item_type_id AND r.item_id = i.item_id) 
+                             OR (r.item_type_id = 2 AND r.item_id = i.microcosm_id)
+                            )
+                        AND r.profile_id = in_profile_id
+                 WHERE i.item_type_id = in_item_type_id
+                   AND i.item_id = in_item_id
+                 ORDER BY r.read DESC
+                 LIMIT 1
+               ) AS u
+         WHERE unread;
+
+    WHEN 12 THEN -- album
+
+        RETURN COUNT(*) > 0 AS has_unread
+          FROM (
+                SELECT COALESCE(i.last_modified > r.read, true) AS unread
+                  FROM flags i
+                       LEFT JOIN "read" r
+                         ON (
+                                (r.item_type_id = i.item_type_id AND r.item_id = i.item_id) 
+                             OR (r.item_type_id = 2 AND r.item_id = i.microcosm_id)
+                            )
+                        AND r.profile_id = in_profile_id
+                 WHERE i.item_type_id = in_item_type_id
+                   AND i.item_id = in_item_id
+                 ORDER BY r.read DESC
+                 LIMIT 1
+               ) AS u
+         WHERE unread;
+
+    WHEN 13 THEN -- attendee
+    WHEN 14 THEN -- user
+    WHEN 15 THEN -- attribute
+    WHEN 16 THEN -- update
+    WHEN 17 THEN -- role
+    WHEN 18 THEN -- update type
+    WHEN 19 THEN -- watcher
+    END CASE;
+
+    RETURN false;
+
+END;
+$BODY$
+  LANGUAGE plpgsql STABLE
+  COST 100;
+-- +goose StatementEnd
+
+-- +goose Down
+-- SQL section 'Down' is executed when this migration is rolled back
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION has_unread(
+    in_item_type_id bigint DEFAULT 0,
+    in_item_id bigint DEFAULT 0,
+    in_profile_id bigint DEFAULT 0)
+  RETURNS boolean AS
+$BODY$
+DECLARE
+BEGIN
+
+    IF in_profile_id = 0 THEN
+        RETURN false;
+    END IF;
+
+    CASE in_item_type_id
+    WHEN 1 THEN -- site
+    WHEN 2 THEN -- microcosm
+
+        -- Check the last read of the microcosm against the read time
+        IF NOT (SELECT COALESCE(
+                (
+                    SELECT last_modified
+                      FROM flags
+                     WHERE microcosm_id = in_item_id
+                       AND item_type_id IN (6, 9)
+                       AND NOT item_is_deleted
+                       AND NOT item_is_moderated
+                       AND last_modified > (
+                               SELECT read
+                                 FROM read
+                                WHERE profile_id = in_profile_id
+                                  AND item_type_id = in_item_type_id
+                                  AND item_id = in_item_id
+                           )
+                     ORDER BY last_modified DESC
+                     LIMIT 1
+                ) > (
+                    SELECT read
+                      FROM read
+                     WHERE profile_id = in_profile_id
+                       AND item_type_id = in_item_type_id
+                       AND item_id = in_item_id
+                ), true)) THEN
+            RETURN false;
+        END IF;
+
+        -- We don't have a recent last_read indicator, and need to call
+        -- has_unread for items... but if we do have an old read row for
+        -- the microcosm then we only need to check the items since that
+        -- time.
+        IF (SELECT COUNT(*)
+              FROM read
+             WHERE profile_id = in_profile_id
+               AND item_type_id = in_item_type_id
+               AND item_id = in_item_id ) > 0 THEN
+
+            RETURN (SELECT EXISTS(
+                        SELECT 1
+                          FROM flags
+                         WHERE microcosm_id = in_item_id
+                           AND item_type_id IN (6, 9)
+                           AND NOT item_is_deleted
+                           AND NOT item_is_moderated
+                           AND last_modified > (
+                                   SELECT read
+                                     FROM read
+                                    WHERE profile_id = in_profile_id
+                                      AND item_type_id = in_item_type_id
+                                      AND item_id = in_item_id
+                               )
+                           AND has_unread(item_type_id, item_id, in_profile_id)
+                         ORDER BY last_modified DESC
+                   ));
+
+        ELSE
+
+            -- The really slow way, iterate every item until we hit something unread
+            RETURN (SELECT EXISTS(
+                        SELECT 1
+                          FROM flags
+                         WHERE microcosm_id = in_item_id
+                           AND item_type_id IN (6, 9)
+                           AND NOT item_is_deleted
+                           AND NOT item_is_moderated
+                           AND has_unread(item_type_id, item_id, in_profile_id)
+                         ORDER BY last_modified DESC
+                   ));
+        END IF;
+
+    WHEN 3 THEN -- profile
+    WHEN 4 THEN -- comment
+    WHEN 5 THEN -- huddle
+
+        -- Check the last read of all huddles against the read time
+        IF NOT (SELECT COALESCE(
+                (
+                    SELECT last_modified
+                      FROM flags
+                     WHERE item_type_id = 5
+                       AND item_id = in_item_id
+                       AND NOT item_is_deleted
+                       AND NOT item_is_moderated
+                       AND last_modified > (
+                               SELECT read
+                                 FROM read
+                                WHERE profile_id = in_profile_id
+                                  AND item_type_id = 5
+                                  AND item_id = 0
+                           )
+                ) > (
+                    SELECT read
+                      FROM read
+                     WHERE profile_id = in_profile_id
+                       AND item_type_id = 5
+                       AND item_id = 0
+                ), true)) THEN
+            RETURN false;
+        END IF;
+
+
+        -- We don't have a recent last_read indicator, and need to call
+        -- has_unread for items... but if we do have an old read row for
+        -- all huddles then we only need to check the items since that
+        -- time.
+        IF (SELECT EXISTS(
+            SELECT 1
+              FROM read
+             WHERE profile_id = in_profile_id
+               AND item_type_id = 5
+               AND item_id = 0 )) THEN
+
+            RETURN (SELECT EXISTS(
+                       SELECT 1
+                         FROM (            
+                        SELECT COALESCE(f.last_modified > GREATEST(MAX(r.read), r2.read), true) AS unread
+                          FROM flags f
+                               LEFT JOIN read r ON r.item_type_id = 5
+                                               AND r.item_id = in_item_id
+                                               AND r.profile_id = in_profile_id
+                              ,(
+                                   SELECT read
+                                     FROM read
+                                    WHERE profile_id = in_profile_Id
+                                      AND item_type_id = 5
+                                      AND item_id = 0
+                               ) r2
+                         WHERE f.item_type_id = 5
+                           AND f.item_id = in_item_id
+                           AND f.item_is_deleted IS NOT TRUE
+                           AND f.item_is_moderated IS NOT TRUE
+                         GROUP BY f.last_modified, r2.read
+                               ) as u
+                         WHERE unread
+                   ));
+
+        ELSE
+
+            -- The really slow way, iterate every item until we hit something unread
+            RETURN (SELECT EXISTS(
+                        SELECT 1
+                          FROM (
+                                SELECT COALESCE(i.last_modified > MAX(r.read), true) AS unread
+                                  FROM flags i
+                                       LEFT JOIN read r ON r.item_type_id = in_item_type_id
+                                                       AND r.item_id = in_item_id
+                                                       AND r.profile_id = in_profile_id
+                                 WHERE i.item_type_id = in_item_type_id
+                                   AND i.item_id = in_item_id
+                                 GROUP BY r.read, i.last_modified
+                               ) AS u
+                         WHERE unread
+                   ));
+
+        END IF;
+
+    WHEN 6 THEN -- conversation
+
+        RETURN COUNT(*) > 0 AS has_unread
+          FROM (
+                SELECT COALESCE(i.last_modified > r.read, true) AS unread
+                  FROM flags i
+                       LEFT JOIN "read" r
+                         ON (
+                                (r.item_type_id = i.item_type_id AND r.item_id = i.item_id) 
+                             OR (r.item_type_id = 2 AND r.item_id = i.microcosm_id)
+                            )
+                        AND r.profile_id = in_profile_id
+                 WHERE i.item_type_id = in_item_type_id
+                   AND i.item_id = in_item_id
+                 ORDER BY r.read DESC
+                 LIMIT 1
+               ) AS u
+         WHERE unread;
+
+    WHEN 7 THEN -- poll
+
+        RETURN COUNT(*) > 0 AS has_unread
+          FROM (
+                SELECT COALESCE(i.last_modified > r.read, true) AS unread
+                  FROM flags i
+                       LEFT JOIN "read" r
+                         ON (
+                                (r.item_type_id = i.item_type_id AND r.item_id = i.item_id) 
+                             OR (r.item_type_id = 2 AND r.item_id = i.microcosm_id)
+                            )
+                        AND r.profile_id = in_profile_id
+                 WHERE i.item_type_id = in_item_type_id
+                   AND i.item_id = in_item_id
+                 ORDER BY r.read DESC
+                 LIMIT 1
+               ) AS u
+         WHERE unread;
+
+    WHEN 8 THEN -- article
+
+        RETURN COUNT(*) > 0 AS has_unread
+          FROM (
+                SELECT COALESCE(i.last_modified > r.read, true) AS unread
+                  FROM flags i
+                       LEFT JOIN "read" r
+                         ON (
+                                (r.item_type_id = i.item_type_id AND r.item_id = i.item_id) 
+                             OR (r.item_type_id = 2 AND r.item_id = i.microcosm_id)
+                            )
+                        AND r.profile_id = in_profile_id
+                 WHERE i.item_type_id = in_item_type_id
+                   AND i.item_id = in_item_id
+                 ORDER BY r.read DESC
+                 LIMIT 1
+               ) AS u
+         WHERE unread;
+
+    WHEN 9 THEN -- event
+
+        RETURN COUNT(*) > 0 AS has_unread
+          FROM (
+                SELECT COALESCE(i.last_modified > r.read, true) AS unread
+                  FROM flags i
+                       LEFT JOIN "read" r
+                         ON (
+                                (r.item_type_id = i.item_type_id AND r.item_id = i.item_id) 
+                             OR (r.item_type_id = 2 AND r.item_id = i.microcosm_id)
+                            )
+                        AND r.profile_id = in_profile_id
+                 WHERE i.item_type_id = in_item_type_id
+                   AND i.item_id = in_item_id
+                 ORDER BY r.read DESC
+                 LIMIT 1
+               ) AS u
+         WHERE unread;
+
+    WHEN 10 THEN -- question
+
+        RETURN COUNT(*) > 0 AS has_unread
+          FROM (
+                SELECT COALESCE(i.last_modified > r.read, true) AS unread
+                  FROM flags i
+                       LEFT JOIN "read" r
+                         ON (
+                                (r.item_type_id = i.item_type_id AND r.item_id = i.item_id) 
+                             OR (r.item_type_id = 2 AND r.item_id = i.microcosm_id)
+                            )
+                        AND r.profile_id = in_profile_id
+                 WHERE i.item_type_id = in_item_type_id
+                   AND i.item_id = in_item_id
+                 ORDER BY r.read DESC
+                 LIMIT 1
+               ) AS u
+         WHERE unread;
+
+    WHEN 11 THEN -- classified
+
+        RETURN COUNT(*) > 0 AS has_unread
+          FROM (
+                SELECT COALESCE(i.last_modified > r.read, true) AS unread
+                  FROM flags i
+                       LEFT JOIN "read" r
+                         ON (
+                                (r.item_type_id = i.item_type_id AND r.item_id = i.item_id) 
+                             OR (r.item_type_id = 2 AND r.item_id = i.microcosm_id)
+                            )
+                        AND r.profile_id = in_profile_id
+                 WHERE i.item_type_id = in_item_type_id
+                   AND i.item_id = in_item_id
+                 ORDER BY r.read DESC
+                 LIMIT 1
+               ) AS u
+         WHERE unread;
+
+    WHEN 12 THEN -- album
+
+        RETURN COUNT(*) > 0 AS has_unread
+          FROM (
+                SELECT COALESCE(i.last_modified > r.read, true) AS unread
+                  FROM flags i
+                       LEFT JOIN "read" r
+                         ON (
+                                (r.item_type_id = i.item_type_id AND r.item_id = i.item_id) 
+                             OR (r.item_type_id = 2 AND r.item_id = i.microcosm_id)
+                            )
+                        AND r.profile_id = in_profile_id
+                 WHERE i.item_type_id = in_item_type_id
+                   AND i.item_id = in_item_id
+                 ORDER BY r.read DESC
+                 LIMIT 1
+               ) AS u
+         WHERE unread;
+
+    WHEN 13 THEN -- attendee
+    WHEN 14 THEN -- user
+    WHEN 15 THEN -- attribute
+    WHEN 16 THEN -- update
+    WHEN 17 THEN -- role
+    WHEN 18 THEN -- update type
+    WHEN 19 THEN -- watcher
+    END CASE;
+
+    RETURN false;
+
+END;
+$BODY$
+  LANGUAGE plpgsql STABLE
+  COST 100;
+-- +goose StatementEnd

--- a/models/attendees.go
+++ b/models/attendees.go
@@ -116,8 +116,8 @@ SELECT rsvp_spaces
 	return http.StatusOK, nil
 }
 
-// FetchProfileSummaries populates a partially populated struct
-func (m *AttendeeType) FetchProfileSummaries(siteID int64) (int, error) {
+// Hydrate populates a partially populated struct
+func (m *AttendeeType) Hydrate(siteID int64) (int, error) {
 
 	profile, status, err := GetProfileSummary(siteID, m.ProfileID)
 	if err != nil {
@@ -417,7 +417,7 @@ func GetAttendee(siteID int64, id int64) (AttendeeType, int, error) {
 	mcKey := fmt.Sprintf(mcAttendeeKeys[c.CacheDetail], id)
 	if val, ok := c.Get(mcKey, AttendeeType{}); ok {
 		m := val.(AttendeeType)
-		m.FetchProfileSummaries(siteID)
+		m.Hydrate(siteID)
 		return m, 0, nil
 	}
 
@@ -495,7 +495,7 @@ WHERE attendee_id = $1`,
 
 	// Update cache
 	c.Set(mcKey, m, mcTTL)
-	m.FetchProfileSummaries(siteID)
+	m.Hydrate(siteID)
 
 	return m, http.StatusOK, nil
 }

--- a/models/attributes.go
+++ b/models/attributes.go
@@ -320,9 +320,10 @@ func DeleteManyAttributes(
 			if err != nil {
 				return status, err
 			}
+			m.ID = attributeID
 		}
 
-		status, err := m.delete(tx, attributeID)
+		status, err := m.delete(tx)
 		if err != nil {
 			return status, err
 		}
@@ -345,7 +346,7 @@ func (m *AttributeType) Delete() (int, error) {
 	}
 	defer tx.Rollback()
 
-	status, err := m.delete(tx, m.ID)
+	status, err := m.delete(tx)
 	if err != nil {
 		return status, err
 	}
@@ -359,11 +360,11 @@ func (m *AttributeType) Delete() (int, error) {
 	return http.StatusOK, nil
 }
 
-func (m *AttributeType) delete(tx *sql.Tx, attributeID int64) (int, error) {
+func (m *AttributeType) delete(tx *sql.Tx) (int, error) {
 	_, err := tx.Exec(`
 DELETE FROM attribute_values
  WHERE attribute_id = $1`,
-		attributeID,
+		m.ID,
 	)
 	if err != nil {
 		return http.StatusInternalServerError,
@@ -373,7 +374,7 @@ DELETE FROM attribute_values
 	_, err = tx.Exec(`
 DELETE FROM attribute_keys
  WHERE attribute_id = $1`,
-		attributeID,
+		m.ID,
 	)
 	if err != nil {
 		return http.StatusInternalServerError,

--- a/models/cache.go
+++ b/models/cache.go
@@ -121,8 +121,23 @@ func PurgeCache(itemTypeID int64, itemID int64) {
 		}
 
 	case h.ItemTypes[h.ItemTypeMicrocosm]:
-		for _, mcKeyFmt := range mcMicrocosmKeys {
-			c.Delete(fmt.Sprintf(mcKeyFmt, itemID))
+		// Need to purge parents too but not the root.
+		links, _, err := getMicrocosmParents(itemID)
+		if err != nil {
+			glog.Errorf("+%v", err)
+			for _, mcKeyFmt := range mcMicrocosmKeys {
+				c.Delete(fmt.Sprintf(mcKeyFmt, itemID))
+			}
+			return
+		}
+
+		for _, link := range links {
+			if link.Level == 1 {
+				continue
+			}
+			for _, mcKeyFmt := range mcMicrocosmKeys {
+				c.Delete(fmt.Sprintf(mcKeyFmt, link.ID))
+			}
 		}
 
 	case h.ItemTypes[h.ItemTypePoll]:

--- a/models/cache.go
+++ b/models/cache.go
@@ -67,6 +67,7 @@ var (
 		c.CacheSubdomain: "s_sd%s",
 		c.CacheTitle:     "s_t%d",
 		c.CacheCounts:    "s_c%d",
+		c.CacheRootID:    "s_r%d",
 	}
 	mcUpdateKeys = map[int]string{
 		c.CacheDetail: "u_d%d",

--- a/models/cache.go
+++ b/models/cache.go
@@ -25,15 +25,17 @@ var (
 		c.CacheDetail: "cm_d%d",
 	}
 	mcConversationKeys = map[int]string{
-		c.CacheDetail:  "cv_d%d",
-		c.CacheSummary: "cv_s%d",
-		c.CacheItem:    "cv_i%d",
+		c.CacheDetail:     "cv_d%d",
+		c.CacheSummary:    "cv_s%d",
+		c.CacheItem:       "cv_i%d",
+		c.CacheBreadcrumb: "cv_b%d",
 	}
 	mcEventKeys = map[int]string{
 		c.CacheDetail:     "ev_d%d",
 		c.CacheSummary:    "ev_s%d",
 		c.CacheItem:       "ev_i%d",
 		c.CacheProfileIds: "ev_l%d",
+		c.CacheBreadcrumb: "ev_b%d",
 	}
 	mcHuddleKeys = map[int]string{
 		c.CacheDetail:  "hd_d%d",
@@ -42,14 +44,16 @@ var (
 		c.CacheTitle:   "hd_t%d",
 	}
 	mcMicrocosmKeys = map[int]string{
-		c.CacheDetail:  "ms_d%d",
-		c.CacheSummary: "ms_s%d",
-		c.CacheTitle:   "ms_t%d",
+		c.CacheDetail:     "ms_d%d",
+		c.CacheSummary:    "ms_s%d",
+		c.CacheTitle:      "ms_t%d",
+		c.CacheBreadcrumb: "ms_b%d",
 	}
 	mcPollKeys = map[int]string{
-		c.CacheDetail:  "po_d%d",
-		c.CacheSummary: "po_s%d",
-		c.CacheItem:    "po_i%d",
+		c.CacheDetail:     "po_d%d",
+		c.CacheSummary:    "po_s%d",
+		c.CacheItem:       "po_i%d",
+		c.CacheBreadcrumb: "po_b%d",
 	}
 	mcProfileKeys = map[int]string{
 		c.CacheDetail:  "pr_d%d",

--- a/models/comments.go
+++ b/models/comments.go
@@ -159,8 +159,8 @@ func (m *CommentSummaryType) Validate(siteID int64, exists bool) (int, error) {
 	return http.StatusOK, nil
 }
 
-// FetchProfileSummaries populates a partially populated struct
-func (m *CommentSummaryType) FetchProfileSummaries(siteID int64) (int, error) {
+// Hydrate populates a partially populated struct
+func (m *CommentSummaryType) Hydrate(siteID int64) (int, error) {
 
 	profile, status, err := GetProfileSummary(siteID, m.Meta.CreatedByID)
 	if err != nil {
@@ -898,7 +898,7 @@ func GetCommentSummary(
 	if val, ok := c.Get(mcKey, CommentSummaryType{}); ok {
 		m := val.(CommentSummaryType)
 
-		m.FetchProfileSummaries(siteID)
+		m.Hydrate(siteID)
 
 		return m, http.StatusOK, nil
 	}
@@ -1104,7 +1104,7 @@ UPDATE revisions
 	c.Set(mcKey, m, commentTTL)
 
 	// Profiles should be fetched after the item is cached.
-	m.FetchProfileSummaries(siteID)
+	m.Hydrate(siteID)
 
 	return m, http.StatusOK, nil
 }

--- a/models/conversations.go
+++ b/models/conversations.go
@@ -647,9 +647,9 @@ func GetConversations(
 WITH m AS (
     SELECT m.microcosm_id
       FROM microcosms m
-      LEFT JOIN ignores i ON i.profile_id = $3
-                         AND i.item_type_id = 2
-                         AND i.item_id = m.microcosm_id
+      LEFT JOIN ignores_expanded i ON i.profile_id = $3
+                                  AND i.item_type_id = 2
+                                  AND i.item_id = m.microcosm_id
      WHERE i.profile_id IS NULL
        AND (get_effective_permissions(m.site_id, m.microcosm_id, 2, m.microcosm_id, $3)).can_read IS TRUE
 )

--- a/models/conversations.go
+++ b/models/conversations.go
@@ -53,11 +53,9 @@ func (m *ConversationType) Validate(
 
 	if !exists {
 		// Does the Microcosm specified exist on this site?
-		fetchChildren := false
 		_, status, err := GetMicrocosmSummary(
 			siteID,
 			m.MicrocosmID,
-			fetchChildren,
 			profileID,
 		)
 		if err != nil {

--- a/models/conversations.go
+++ b/models/conversations.go
@@ -53,7 +53,13 @@ func (m *ConversationType) Validate(
 
 	if !exists {
 		// Does the Microcosm specified exist on this site?
-		_, status, err := GetMicrocosmSummary(siteID, m.MicrocosmID, profileID)
+		fetchChildren := false
+		_, status, err := GetMicrocosmSummary(
+			siteID,
+			m.MicrocosmID,
+			fetchChildren,
+			profileID,
+		)
 		if err != nil {
 			return status, err
 		}

--- a/models/conversations.go
+++ b/models/conversations.go
@@ -92,8 +92,8 @@ func (m *ConversationType) Validate(
 	return http.StatusOK, nil
 }
 
-// FetchSummaries populates a partially populated struct
-func (m *ConversationType) FetchSummaries(siteID int64) (int, error) {
+// Hydrate populates a partially populated struct
+func (m *ConversationType) Hydrate(siteID int64) (int, error) {
 
 	profile, status, err := GetProfileSummary(siteID, m.Meta.CreatedByID)
 	if err != nil {
@@ -110,11 +110,15 @@ func (m *ConversationType) FetchSummaries(siteID int64) (int, error) {
 		m.Meta.EditedBy = profile
 	}
 
+	if status, err := m.FetchBreadcrumb(); err != nil {
+		return status, err
+	}
+
 	return http.StatusOK, nil
 }
 
-// FetchProfileSummaries populates a partially populated struct
-func (m *ConversationSummaryType) FetchProfileSummaries(
+// Hydrate populates a partially populated struct
+func (m *ConversationSummaryType) Hydrate(
 	siteID int64,
 ) (
 	int,
@@ -138,6 +142,10 @@ func (m *ConversationSummaryType) FetchProfileSummaries(
 
 		lastComment.CreatedBy = profile
 		m.LastComment = lastComment
+	}
+
+	if status, err := m.FetchBreadcrumb(); err != nil {
+		return status, err
 	}
 
 	return http.StatusOK, nil
@@ -421,9 +429,7 @@ func GetConversation(
 	if val, ok := c.Get(mcKey, ConversationType{}); ok {
 		m := val.(ConversationType)
 
-		// TODO(buro9) 2014-05-05: We are not verifying that the cached
-		// conversation belongs to this siteId
-		m.FetchSummaries(siteID)
+		m.Hydrate(siteID)
 
 		return m, http.StatusOK, nil
 	}
@@ -514,7 +520,7 @@ SELECT c.conversation_id
 	// Update cache
 	c.Set(mcKey, m, mcTTL)
 
-	m.FetchSummaries(siteID)
+	m.Hydrate(siteID)
 	return m, http.StatusOK, nil
 }
 
@@ -532,7 +538,7 @@ func GetConversationSummary(
 	mcKey := fmt.Sprintf(mcConversationKeys[c.CacheSummary], id)
 	if val, ok := c.Get(mcKey, ConversationSummaryType{}); ok {
 		m := val.(ConversationSummaryType)
-		m.FetchProfileSummaries(siteID)
+		m.Hydrate(siteID)
 		return m, http.StatusOK, nil
 	}
 
@@ -619,7 +625,7 @@ SELECT conversation_id
 	// Update cache
 	c.Set(mcKey, m, mcTTL)
 
-	m.FetchProfileSummaries(siteID)
+	m.Hydrate(siteID)
 	return m, http.StatusOK, nil
 }
 

--- a/models/cron.go
+++ b/models/cron.go
@@ -192,10 +192,11 @@ func UpdateMicrocosmItemCounts() {
    SET comment_count = s.comment_count
       ,item_count = s.item_count
   FROM (
-           SELECT microcosm_id
-                 ,SUM(item_count) AS item_count
-                 ,SUM(comment_count) AS comment_count
-             FROM (
+           SELECT dm.microcosm_id
+                 ,COALESCE(SUM(counts.item_count), 0) AS item_count
+                 ,COALESCE(SUM(counts.comment_count), 0) AS comment_count
+             FROM microcosms dm
+             LEFT JOIN (
                       -- Calculate item counts
                       SELECT microcosm_id
                             ,COUNT(*) AS item_count
@@ -224,8 +225,8 @@ func UpdateMicrocosmItemCounts() {
                          AND item_is_deleted IS NOT TRUE
                          AND item_is_moderated IS NOT TRUE
                        GROUP BY microcosm_id
-                  ) counts
-            GROUP BY microcosm_id
+                  ) counts ON dm.microcosm_id = counts.microcosm_id
+            GROUP BY dm.microcosm_id
        ) s
  WHERE m.microcosm_id = s.microcosm_id
    AND (

--- a/models/events.go
+++ b/models/events.go
@@ -1020,9 +1020,9 @@ func GetEvents(
 WITH m AS (
     SELECT m.microcosm_id
       FROM microcosms m
-      LEFT JOIN ignores i ON i.profile_id = $3
-                         AND i.item_type_id = 2
-                         AND i.item_id = m.microcosm_id
+      LEFT JOIN ignores_expanded i ON i.profile_id = $3
+                                  AND i.item_type_id = 2
+                                  AND i.item_id = m.microcosm_id
      WHERE i.profile_id IS NULL
        AND (get_effective_permissions(m.site_id, m.microcosm_id, 2, m.microcosm_id, $3)).can_read IS TRUE
 )

--- a/models/events.go
+++ b/models/events.go
@@ -101,7 +101,13 @@ func (m *EventType) Validate(
 
 	// Does the Microcosm specified exist on this site?
 	if !exists {
-		_, status, err := GetMicrocosmSummary(siteID, m.MicrocosmID, profileID)
+		fetchChildren := false
+		_, status, err := GetMicrocosmSummary(
+			siteID,
+			m.MicrocosmID,
+			fetchChildren,
+			profileID,
+		)
 		if err != nil {
 			glog.Infof(`GetMicrocosmSummary error %+v`, err)
 			return status, err

--- a/models/events.go
+++ b/models/events.go
@@ -101,11 +101,9 @@ func (m *EventType) Validate(
 
 	// Does the Microcosm specified exist on this site?
 	if !exists {
-		fetchChildren := false
 		_, status, err := GetMicrocosmSummary(
 			siteID,
 			m.MicrocosmID,
-			fetchChildren,
 			profileID,
 		)
 		if err != nil {

--- a/models/huddles.go
+++ b/models/huddles.go
@@ -90,8 +90,8 @@ func (m *HuddleType) Validate(siteID int64, exists bool) (int, error) {
 	return http.StatusOK, nil
 }
 
-// FetchProfileSummaries populates the partially populated huddle
-func (m *HuddleType) FetchProfileSummaries(siteID int64) (int, error) {
+// Hydrate populates the partially populated huddle
+func (m *HuddleType) Hydrate(siteID int64) (int, error) {
 	profile, status, err := GetProfileSummary(siteID, m.Meta.CreatedByID)
 	if err != nil {
 		return status, err
@@ -109,8 +109,8 @@ func (m *HuddleType) FetchProfileSummaries(siteID int64) (int, error) {
 	return http.StatusOK, nil
 }
 
-// FetchProfileSummaries populates the partially populated huddle summary
-func (m *HuddleSummaryType) FetchProfileSummaries(siteID int64) (int, error) {
+// Hydrate populates the partially populated huddle summary
+func (m *HuddleSummaryType) Hydrate(siteID int64) (int, error) {
 
 	profile, status, err := GetProfileSummary(siteID, m.Meta.CreatedByID)
 	if err != nil {
@@ -298,7 +298,7 @@ func GetHuddle(
 	mcKey := fmt.Sprintf(mcHuddleKeys[c.CacheDetail], id)
 	if val, ok := c.Get(mcKey, HuddleType{}); ok {
 		m := val.(HuddleType)
-		m.FetchProfileSummaries(siteID)
+		m.Hydrate(siteID)
 		return m, http.StatusOK, nil
 	}
 
@@ -371,7 +371,7 @@ SELECT h.huddle_id
 	// Update cache
 	c.Set(mcKey, m, mcTTL)
 
-	m.FetchProfileSummaries(siteID)
+	m.Hydrate(siteID)
 
 	return m, http.StatusOK, nil
 }
@@ -425,7 +425,7 @@ func GetHuddleSummary(
 	mcKey := fmt.Sprintf(mcHuddleKeys[c.CacheSummary], id)
 	if val, ok := c.Get(mcKey, HuddleSummaryType{}); ok {
 		m := val.(HuddleSummaryType)
-		m.FetchProfileSummaries(siteID)
+		m.Hydrate(siteID)
 		return m, http.StatusOK, nil
 	}
 
@@ -554,7 +554,7 @@ SELECT h.huddle_id
 	// Update cache
 	c.Set(mcKey, m, mcTTL)
 
-	m.FetchProfileSummaries(siteID)
+	m.Hydrate(siteID)
 
 	return m, http.StatusOK, nil
 }

--- a/models/init.go
+++ b/models/init.go
@@ -22,6 +22,7 @@ func init() {
 	gob.Register(LastComment{})
 	gob.Register(MicrocosmSummaryType{})
 	gob.Register(MicrocosmType{})
+	gob.Register([]MicrocosmLinkType{})
 	gob.Register(PollSummaryType{})
 	gob.Register(PollType{})
 	gob.Register(ProfileOptionType{})

--- a/models/items.go
+++ b/models/items.go
@@ -350,8 +350,8 @@ SELECT item_type_id
   FROM (
         SELECT f.item_type_id
               ,f.item_id`+sqlFromWhere+`
-         ORDER BY f.item_type_id = 2 DESC
-                 ,f.item_is_sticky DESC
+         ORDER BY f.item_is_sticky DESC
+                 ,f.item_type_id = 2 DESC
                  ,f.last_modified DESC
          LIMIT $4
         OFFSET $5

--- a/models/items.go
+++ b/models/items.go
@@ -15,6 +15,7 @@ import (
 	h "github.com/microcosm-cc/microcosm/helpers"
 )
 
+// ItemParent describes the ancestor microcosms this item belongs to
 type ItemParent struct {
 	MicrocosmID int64                `json:"microcosmId"`
 	Breadcrumb  *[]MicrocosmLinkType `json:"breadcrumb,omitempty"`

--- a/models/items.go
+++ b/models/items.go
@@ -206,10 +206,7 @@ UPDATE polls
 		_, err = db.Exec(`--Update Microcosm Comment Count
 UPDATE microcosms
    SET comment_count = comment_count + 1
- WHERE path @> (
-           SELECT path FROM microcosms WHERE microcosm_id = $1
-       )
-   AND parent_id IS NOT NULL`,
+ WHERE microcosm_id = $1`,
 			microcosmID,
 		)
 		if err != nil {
@@ -285,10 +282,7 @@ UPDATE polls
 		_, err = db.Exec(`--Update Microcosm Comment Count
 UPDATE microcosms
    SET comment_count = comment_count - 1
- WHERE path @> (
-           SELECT path FROM microcosms WHERE microcosm_id = $1
-       )
-   AND parent_id IS NOT NULL`,
+ WHERE microcosm_id = $1`,
 			microcosmID,
 		)
 		if err != nil {

--- a/models/items.go
+++ b/models/items.go
@@ -350,7 +350,7 @@ SELECT item_type_id
   FROM (
         SELECT f.item_type_id
               ,f.item_id`+sqlFromWhere+`
-         ORDER BY f.item_type_id = 2
+         ORDER BY f.item_type_id = 2 DESC
                  ,f.item_is_sticky DESC
                  ,f.last_modified DESC
          LIMIT $4

--- a/models/items.go
+++ b/models/items.go
@@ -314,7 +314,7 @@ func GetAllItems(
                    SELECT $2::bigint AS microcosm_id
                     WHERE (get_effective_permissions($1, $2, 2, $2, $3)).can_read IS TRUE
                )
-           AND (f.item_type_id = 6 OR f.item_type_id = 9)
+           AND f.item_type_id IN (2, 6, 9)
            AND f.site_id = $1
            AND i.profile_id IS NULL
            AND f.microcosm_is_deleted IS NOT TRUE
@@ -350,7 +350,8 @@ SELECT item_type_id
   FROM (
         SELECT f.item_type_id
               ,f.item_id`+sqlFromWhere+`
-         ORDER BY f.item_is_sticky DESC
+         ORDER BY f.item_type_id = 2
+                 ,f.item_is_sticky DESC
                  ,f.last_modified DESC
          LIMIT $4
         OFFSET $5

--- a/models/microcosms.go
+++ b/models/microcosms.go
@@ -79,7 +79,7 @@ type MicrocosmLinkType struct {
 	Title            string `json:"title,omitempty"`
 	ID               int64  `json:"id"`
 	Level            int64  `json:"level,omitempty"`
-	ParentID         int64  `json:"parentID,omitempty"`
+	ParentID         int64  `json:"parentId,omitempty"`
 	parentIDNullable sql.NullInt64
 }
 

--- a/models/microcosms.go
+++ b/models/microcosms.go
@@ -67,11 +67,6 @@ type MicrocosmSummaryRequest struct {
 	Seq    int
 }
 
-// MicrocosmLinkForestType is a collection of Microcosm links organised as trees
-type MicrocosmLinkForestType struct {
-	Links []MicrocosmLinkForestType `json:"forest"`
-}
-
 // MicrocosmLinkType is a link
 type MicrocosmLinkType struct {
 	Rel              string `json:"rel,omitempty"` // REST

--- a/models/microcosms.go
+++ b/models/microcosms.go
@@ -856,9 +856,9 @@ WITH m AS (
                                    AND p.item_type_id = 2
                                    AND p.item_id = m.microcosm_id
                                    AND p.profile_id = $2
-           LEFT JOIN ignores i ON i.profile_id = $2
-                              AND i.item_type_id = 2
-                              AND i.item_id = m.microcosm_id
+           LEFT JOIN ignores_expanded i ON i.profile_id = $2
+                                       AND i.item_type_id = 2
+                                       AND i.item_id = m.microcosm_id
      WHERE m.site_id = $1`+sqlChild+sqlIsRoot+`
        AND m.is_deleted IS NOT TRUE
        AND m.is_moderated IS NOT TRUE

--- a/models/microcosms.go
+++ b/models/microcosms.go
@@ -264,12 +264,10 @@ INSERT INTO microcosms (
 	}
 	m.ID = insertID
 
-	if m.parentIDNullable.Valid && m.parentIDNullable.Int64 != 0 {
-		purgeCache := false
-		status, err := updateMicrocosmPaths(tx, m.SiteID, purgeCache)
-		if err != nil {
-			return status, err
-		}
+	purgeCache := false
+	status, err := updateMicrocosmPaths(tx, m.SiteID, purgeCache)
+	if err != nil {
+		return status, err
 	}
 
 	err = tx.Commit()

--- a/models/microcosms.go
+++ b/models/microcosms.go
@@ -26,15 +26,14 @@ type MicrocosmSummaryType struct {
 	ID               int64 `json:"id"`
 	ParentID         int64 `json:"parentId,omitempty"`
 	parentIDNullable sql.NullInt64
-	SiteID           int64                  `json:"siteId,omitempty"`
-	Visibility       string                 `json:"visibility"`
-	Title            string                 `json:"title"`
-	Description      string                 `json:"description"`
-	Moderators       []int64                `json:"moderators"`
-	ItemCount        int64                  `json:"totalItems"`
-	CommentCount     int64                  `json:"totalComments"`
-	ItemTypes        []string               `json:"itemTypes"`
-	Children         []MicrocosmSummaryType `json:"children,omitempty"`
+	SiteID           int64    `json:"siteId,omitempty"`
+	Visibility       string   `json:"visibility"`
+	Title            string   `json:"title"`
+	Description      string   `json:"description"`
+	Moderators       []int64  `json:"moderators"`
+	ItemCount        int64    `json:"totalItems"`
+	CommentCount     int64    `json:"totalComments"`
+	ItemTypes        []string `json:"itemTypes"`
 
 	MRU interface{} `json:"mostRecentUpdate,omitempty"`
 
@@ -46,13 +45,13 @@ type MicrocosmType struct {
 	ID               int64 `json:"id"`
 	ParentID         int64 `json:"parentId,omitempty"`
 	parentIDNullable sql.NullInt64
-	SiteID           int64                  `json:"siteId,omitempty"`
-	Visibility       string                 `json:"visibility"`
-	Title            string                 `json:"title"`
-	Description      string                 `json:"description"`
-	OwnedByID        int64                  `json:"-"`
-	ItemTypes        []string               `json:"itemTypes"`
-	Children         []MicrocosmSummaryType `json:"children,omitempty"`
+	SiteID           int64               `json:"siteId,omitempty"`
+	Visibility       string              `json:"visibility"`
+	Title            string              `json:"title"`
+	Description      string              `json:"description"`
+	OwnedByID        int64               `json:"-"`
+	ItemTypes        []string            `json:"itemTypes"`
+	Parents          []MicrocosmLinkType `json:"parents,omitempty"`
 
 	Moderators []int64 `json:"moderators"`
 
@@ -548,6 +547,18 @@ SELECT microcosm_id,
 	if m.parentIDNullable.Valid {
 		m.ParentID = m.parentIDNullable.Int64
 	}
+
+	parents, status, err := getMicrocosmParents(m.ID)
+	if err != nil {
+		return MicrocosmType{}, status, err
+	}
+	for _, parent := range parents {
+		if parent.ID == m.ID || parent.Level == 1 {
+			continue
+		}
+		m.Parents = append(m.Parents, parent)
+	}
+
 	if m.Meta.EditReasonNullable.Valid {
 		m.Meta.EditReason = m.Meta.EditReasonNullable.String
 	}

--- a/models/microcosms.go
+++ b/models/microcosms.go
@@ -1057,7 +1057,3 @@ SELECT microcosm_id
 
 	return links, http.StatusOK, nil
 }
-
-func getMicrocosmTree() (MicrocosmLinkForestType, int, error) {
-	return MicrocosmLinkForestType{}, http.StatusOK, nil
-}

--- a/models/polls.go
+++ b/models/polls.go
@@ -157,9 +157,8 @@ func (m *PollType) Validate(
 	return http.StatusOK, nil
 }
 
-// FetchProfileSummaries populates a partially populated struct
-func (m *PollType) FetchProfileSummaries(siteID int64) (int, error) {
-
+// Hydrate populates a partially populated struct
+func (m *PollType) Hydrate(siteID int64) (int, error) {
 	profile, status, err := GetProfileSummary(siteID, m.Meta.CreatedByID)
 	if err != nil {
 		return status, err
@@ -175,17 +174,24 @@ func (m *PollType) FetchProfileSummaries(siteID int64) (int, error) {
 		m.Meta.EditedBy = profile
 	}
 
+	if status, err := m.FetchBreadcrumb(); err != nil {
+		return status, err
+	}
+
 	return http.StatusOK, nil
 }
 
-// FetchProfileSummaries populates a partially populated struct
-func (m *PollSummaryType) FetchProfileSummaries(siteID int64) (int, error) {
-
+// Hydrate populates a partially populated struct
+func (m *PollSummaryType) Hydrate(siteID int64) (int, error) {
 	profile, status, err := GetProfileSummary(siteID, m.Meta.CreatedByID)
 	if err != nil {
 		return status, err
 	}
 	m.Meta.CreatedBy = profile
+
+	if status, err := m.FetchBreadcrumb(); err != nil {
+		return status, err
+	}
 
 	return http.StatusOK, nil
 }
@@ -501,7 +507,7 @@ func GetPoll(siteID int64, id int64, profileID int64) (PollType, int, error) {
 	mcKey := fmt.Sprintf(mcPollKeys[c.CacheDetail], id)
 	if val, ok := c.Get(mcKey, PollType{}); ok {
 		m := val.(PollType)
-		m.FetchProfileSummaries(siteID)
+		m.Hydrate(siteID)
 		return m, http.StatusOK, nil
 	}
 
@@ -638,7 +644,7 @@ SELECT choice_id,
 	// Update cache
 	c.Set(mcKey, m, mcTTL)
 
-	m.FetchProfileSummaries(siteID)
+	m.Hydrate(siteID)
 	return m, http.StatusOK, nil
 }
 
@@ -665,7 +671,7 @@ func GetPollSummary(
 		if err != nil {
 			return PollSummaryType{}, status, err
 		}
-		m.FetchProfileSummaries(siteID)
+		m.Hydrate(siteID)
 		return m, 0, nil
 	}
 
@@ -747,7 +753,7 @@ SELECT poll_id
 	// Update cache
 	c.Set(mcKey, m, mcTTL)
 
-	m.FetchProfileSummaries(siteID)
+	m.Hydrate(siteID)
 	return m, http.StatusOK, nil
 }
 

--- a/models/polls.go
+++ b/models/polls.go
@@ -75,7 +75,13 @@ func (m *PollType) Validate(
 
 	// Does the Microcosm specified exist on this site?
 	if !exists {
-		_, status, err := GetMicrocosmSummary(siteID, m.MicrocosmID, profileID)
+		fetchChildren := false
+		_, status, err := GetMicrocosmSummary(
+			siteID,
+			m.MicrocosmID,
+			fetchChildren,
+			profileID,
+		)
 		if err != nil {
 			return status, err
 		}
@@ -653,7 +659,13 @@ func GetPollSummary(
 	mcKey := fmt.Sprintf(mcPollKeys[c.CacheSummary], id)
 	if val, ok := c.Get(mcKey, PollSummaryType{}); ok {
 		m := val.(PollSummaryType)
-		_, status, err := GetMicrocosmSummary(siteID, m.MicrocosmID, profileID)
+		fetchChildren := false
+		_, status, err := GetMicrocosmSummary(
+			siteID,
+			m.MicrocosmID,
+			fetchChildren,
+			profileID,
+		)
 		if err != nil {
 			return PollSummaryType{}, status, err
 		}

--- a/models/polls.go
+++ b/models/polls.go
@@ -75,11 +75,9 @@ func (m *PollType) Validate(
 
 	// Does the Microcosm specified exist on this site?
 	if !exists {
-		fetchChildren := false
 		_, status, err := GetMicrocosmSummary(
 			siteID,
 			m.MicrocosmID,
-			fetchChildren,
 			profileID,
 		)
 		if err != nil {
@@ -659,11 +657,9 @@ func GetPollSummary(
 	mcKey := fmt.Sprintf(mcPollKeys[c.CacheSummary], id)
 	if val, ok := c.Get(mcKey, PollSummaryType{}); ok {
 		m := val.(PollSummaryType)
-		fetchChildren := false
 		_, status, err := GetMicrocosmSummary(
 			siteID,
 			m.MicrocosmID,
-			fetchChildren,
 			profileID,
 		)
 		if err != nil {

--- a/models/profiles.go
+++ b/models/profiles.go
@@ -626,6 +626,31 @@ UPDATE profiles AS p
 	return http.StatusOK, nil
 }
 
+// GetProfileEmail fetches the email address for a profile
+func GetProfileEmail(siteID int64, profileID int64) (email string) {
+	db, err := h.GetConnection()
+	if err != nil {
+		glog.Error(err)
+		return
+	}
+
+	err = db.QueryRow(`--GetProfileEmail
+SELECT u.email
+  FROM users u
+  JOIN profiles p ON p.user_id = u.user_id
+ WHERE p.profile_id = $2
+   AND p.site_id = $1`,
+		siteID,
+		profileID,
+	).Scan(&email)
+	if err != nil {
+		glog.Error(err)
+		return
+	}
+
+	return
+}
+
 // GetProfile fetches a single profile
 func GetProfile(siteID int64, id int64) (ProfileType, int, error) {
 

--- a/models/profiles.go
+++ b/models/profiles.go
@@ -899,31 +899,40 @@ func UpdateUnreadHuddleCount(profileID int64) {
 
 // updateUnreadHuddleCount updates the unread huddle count
 func updateUnreadHuddleCount(tx *sql.Tx, profileID int64) {
-
 	_, err := tx.Exec(`--updateUnreadHuddleCount
 UPDATE profiles
    SET unread_huddles = (
-           SELECT COALESCE(
-                      SUM(
-                          CASE WHEN COALESCE(f.last_modified > r.read, true) THEN
-                              1
-                          ELSE
-                              0
-                          END
-                      ),
-                      0
-                  ) as unreadHuddles
-             FROM huddle_profiles hp
-                  JOIN flags f ON f.item_type_id = 5
-                              AND f.item_id = hp.huddle_id
-             LEFT JOIN read r ON r.profile_id = $1
-                             AND r.item_type_id = 5
-                             AND r.item_id = f.item_id
-             LEFT JOIN read r2 ON r2.profile_id = $1
-                              AND r2.item_type_id = 5
-                              AND r2.item_id = 0
-            WHERE hp.profile_id = $1
-              AND f.last_modified > COALESCE(r2.read, TIMESTAMP WITH TIME ZONE '1970-01-01 12:00:00')
+           SELECT COUNT(*) OVER() AS total
+             FROM flags ff
+             JOIN (
+                      SELECT hp.huddle_id
+                            ,f.last_modified
+                        FROM huddle_profiles hp
+                             JOIN flags f ON f.item_type_id = 5
+                                         AND f.item_id = hp.huddle_id
+                        LEFT JOIN read r ON r.profile_id = $1
+                                        AND r.item_type_id = 5
+                                        AND r.item_id = f.item_id
+                        LEFT JOIN read r2 ON r2.profile_id = $1
+                                         AND r2.item_type_id = 5
+                                         AND r2.item_id = 0
+                       WHERE hp.profile_id = $1
+                         AND f.last_modified > COALESCE(
+                                                   COALESCE(
+                                                       r.read,
+                                                       r2.read
+                                                   ),
+                                                   TIMESTAMP WITH TIME ZONE '1970-01-01 12:00:00'
+                                               )
+                  ) AS h ON ff.parent_item_id = h.huddle_id
+                        AND ff.parent_item_type_id = 5
+                        AND ff.last_modified >= h.last_modified
+             LEFT JOIN ignores i ON i.profile_id = $1
+                                AND i.item_type_id = 3
+                                AND i.item_id = ff.created_by
+            WHERE i.profile_id IS NULL
+            GROUP BY h.huddle_id
+            LIMIT 1
        )
  WHERE profile_id = $1`,
 		profileID,

--- a/models/roles.go
+++ b/models/roles.go
@@ -92,11 +92,9 @@ func (m *RoleType) Validate(
 
 	// Does the Microcosm specified exist on this site?
 	if !exists && m.MicrocosmID > 0 {
-		fetchChildren := false
 		_, status, err := GetMicrocosmSummary(
 			siteID,
 			m.MicrocosmID,
-			fetchChildren,
 			profileID,
 		)
 		if err != nil {
@@ -473,11 +471,9 @@ func GetRole(
 	if val, ok := c.Get(mcKey, RoleType{}); ok {
 
 		m := val.(RoleType)
-		fetchChildren := false
 		_, status, err := GetMicrocosmSummary(
 			siteID,
 			microcosmID,
-			fetchChildren,
 			profileID,
 		)
 		if err != nil {

--- a/models/roles.go
+++ b/models/roles.go
@@ -480,7 +480,7 @@ func GetRole(
 			return RoleType{}, status, err
 		}
 
-		m.FetchProfileSummaries(siteID)
+		m.Hydrate(siteID)
 
 		return m, http.StatusOK, nil
 	}
@@ -591,7 +591,7 @@ SELECT role_id
 	// Update cache
 	c.Set(mcKey, m, mcTTL)
 
-	m.FetchProfileSummaries(siteID)
+	m.Hydrate(siteID)
 
 	return m, http.StatusOK, nil
 }
@@ -657,8 +657,8 @@ func GetRoleSummary(
 	return roleSummary, http.StatusOK, nil
 }
 
-// FetchProfileSummaries populates the profile summaries for a role
-func (m *RoleType) FetchProfileSummaries(siteID int64) (int, error) {
+// Hydrate populates the profile summaries for a role
+func (m *RoleType) Hydrate(siteID int64) (int, error) {
 
 	profile, status, err := GetProfileSummary(siteID, m.Meta.CreatedByID)
 	if err != nil {

--- a/models/roles.go
+++ b/models/roles.go
@@ -92,7 +92,13 @@ func (m *RoleType) Validate(
 
 	// Does the Microcosm specified exist on this site?
 	if !exists && m.MicrocosmID > 0 {
-		_, status, err := GetMicrocosmSummary(siteID, m.MicrocosmID, profileID)
+		fetchChildren := false
+		_, status, err := GetMicrocosmSummary(
+			siteID,
+			m.MicrocosmID,
+			fetchChildren,
+			profileID,
+		)
 		if err != nil {
 			return status, err
 		}
@@ -462,14 +468,18 @@ func GetRole(
 	int,
 	error,
 ) {
-
 	// Get from cache if it's available
 	mcKey := fmt.Sprintf(mcRoleKeys[c.CacheDetail], roleID)
 	if val, ok := c.Get(mcKey, RoleType{}); ok {
 
 		m := val.(RoleType)
-
-		_, status, err := GetMicrocosmSummary(siteID, microcosmID, profileID)
+		fetchChildren := false
+		_, status, err := GetMicrocosmSummary(
+			siteID,
+			microcosmID,
+			fetchChildren,
+			profileID,
+		)
 		if err != nil {
 			return RoleType{}, status, err
 		}

--- a/models/search.go
+++ b/models/search.go
@@ -43,15 +43,18 @@ func Search(
 	int,
 	error,
 ) {
-
 	// Parse the search options and determine what kind of search that we will
 	// be performing.
 	m := SearchResults{
-		Query: GetSearchQueryFromURL(searchURL),
+		Query: GetSearchQueryFromURL(siteID, searchURL, profileID),
 	}
 
 	if !m.Query.Valid {
 		return m, http.StatusOK, nil
+	}
+
+	if len(m.Query.Emails) > 0 {
+		return searchEmail(siteID, searchURL, profileID, m)
 	}
 
 	if strings.Trim(m.Query.Query, " ") != "" {

--- a/models/search_email.go
+++ b/models/search_email.go
@@ -1,0 +1,193 @@
+package models
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/golang/glog"
+
+	h "github.com/microcosm-cc/microcosm/helpers"
+)
+
+func searchEmail(
+	siteID int64,
+	searchURL url.URL,
+	profileID int64,
+	m SearchResults,
+) (
+	SearchResults,
+	int,
+	error,
+) {
+
+	limit, offset, status, err := h.GetLimitAndOffset(searchURL.Query())
+	if err != nil {
+		glog.Errorf("h.GetLimitAndOffset(searchURL.Query()) %+v", err)
+		return m, status, err
+	}
+
+	start := time.Now()
+
+	db, err := h.GetConnection()
+	if err != nil {
+		glog.Errorf("h.GetConnection() %+v", err)
+		return m, http.StatusInternalServerError, err
+	}
+
+	rows, err := db.Query(`--SearchEmails
+SELECT *
+  FROM (
+           SELECT COUNT(*) OVER() AS total
+                 ,3 AS item_type
+                 ,p.profile_id AS item_type_id
+                 ,p.last_active
+                 ,1
+                 ,'' AS highlight
+             FROM users u
+             JOIN profiles p ON p.user_id = u.user_id
+            WHERE u.email = ANY(string_to_array($2, '____'))
+              AND p.site_id = $1
+            ORDER BY p.profile_name ASC
+       ) AS r
+ LIMIT $3
+OFFSET $4`,
+		siteID,
+		strings.Join(m.Query.Emails, `____`),
+		limit,
+		offset,
+	)
+	if err != nil {
+		glog.Errorf(
+			"stmt.Query(%d, %s, %d, %d) %+v",
+			siteID,
+			strings.Join(m.Query.Emails, `,`),
+			limit,
+			offset,
+			err,
+		)
+		return m, http.StatusInternalServerError,
+			fmt.Errorf("Database query failed")
+	}
+	defer rows.Close()
+
+	var total int64
+	rs := []SearchResult{}
+	for rows.Next() {
+		var r SearchResult
+		err = rows.Scan(
+			&total,
+			&r.ItemTypeID,
+			&r.ItemID,
+			&r.LastModified,
+			&r.Rank,
+			&r.Highlight,
+		)
+		if err != nil {
+			glog.Errorf("rows.Scan() %+v", err)
+			return m, http.StatusInternalServerError,
+				fmt.Errorf("Row parsing error")
+		}
+
+		r.ItemType = "profile"
+
+		rs = append(rs, r)
+	}
+	err = rows.Err()
+	if err != nil {
+		glog.Errorf("rows.Err() %+v", err)
+		return m, http.StatusInternalServerError,
+			fmt.Errorf("Error fetching rows")
+	}
+	rows.Close()
+
+	pages := h.GetPageCount(total, limit)
+	maxOffset := h.GetMaxOffset(total, limit)
+
+	if offset > maxOffset {
+		glog.Infoln("offset > maxOffset")
+		return m, http.StatusBadRequest,
+			fmt.Errorf("not enough records, "+
+				"offset (%d) would return an empty page.", offset)
+	}
+
+	// Extract the summaries
+	var wg1 sync.WaitGroup
+	req := make(chan SummaryContainerRequest)
+	defer close(req)
+
+	seq := 0
+	for i := 0; i < len(rs); i++ {
+		go HandleSummaryContainerRequest(
+			siteID,
+			rs[i].ItemTypeID,
+			rs[i].ItemID,
+			profileID,
+			seq,
+			req,
+		)
+		seq++
+		wg1.Add(1)
+
+		if rs[i].ParentItemID.Valid && rs[i].ParentItemID.Int64 > 0 {
+			go HandleSummaryContainerRequest(
+				siteID,
+				rs[i].ParentItemTypeID.Int64,
+				rs[i].ParentItemID.Int64,
+				profileID,
+				seq,
+				req,
+			)
+			seq++
+			wg1.Add(1)
+		}
+	}
+
+	resps := []SummaryContainerRequest{}
+	for i := 0; i < seq; i++ {
+		resp := <-req
+		wg1.Done()
+		resps = append(resps, resp)
+	}
+	wg1.Wait()
+
+	for _, resp := range resps {
+		if resp.Err != nil {
+			return m, resp.Status, resp.Err
+		}
+	}
+
+	sort.Sort(SummaryContainerRequestsBySeq(resps))
+
+	seq = 0
+	for i := 0; i < len(rs); i++ {
+
+		rs[i].Item = resps[seq].Item.Summary
+		seq++
+
+		if rs[i].ParentItemID.Valid && rs[i].ParentItemID.Int64 > 0 {
+			rs[i].ParentItem = resps[seq].Item.Summary
+			seq++
+		}
+	}
+
+	m.Results = h.ConstructArray(
+		rs,
+		"result",
+		total,
+		limit,
+		offset,
+		pages,
+		&searchURL,
+	)
+
+	// return milliseconds
+	m.TimeTaken = time.Now().Sub(start).Nanoseconds() / 1000000
+
+	return m, http.StatusOK, nil
+
+}

--- a/models/search_email.go
+++ b/models/search_email.go
@@ -50,7 +50,7 @@ SELECT *
                  ,'' AS highlight
              FROM users u
              JOIN profiles p ON p.user_id = u.user_id
-            WHERE u.email = ANY(string_to_array($2, '____'))
+            WHERE LOWER(u.email) = ANY(string_to_array($2, '____'))
               AND p.site_id = $1
             ORDER BY p.profile_name ASC
        ) AS r
@@ -65,7 +65,7 @@ OFFSET $4`,
 		glog.Errorf(
 			"stmt.Query(%d, %s, %d, %d) %+v",
 			siteID,
-			strings.Join(m.Query.Emails, `,`),
+			strings.ToLower(strings.Join(m.Query.Emails, `,`)),
 			limit,
 			offset,
 			err,

--- a/models/search_fulltext.go
+++ b/models/search_fulltext.go
@@ -262,9 +262,9 @@ WITH m AS (
                                    AND p.item_type_id = 2
                                    AND p.item_id = m.microcosm_id
                                    AND p.profile_id = $2
-           LEFT JOIN ignores i ON i.profile_id = $2
-                              AND i.item_type_id = 2
-                              AND i.item_id = m.microcosm_id
+           LEFT JOIN ignores_expanded i ON i.profile_id = $2
+                                       AND i.item_type_id = 2
+                                       AND i.item_id = m.microcosm_id
      WHERE m.site_id = $1
        AND m.is_deleted IS NOT TRUE
        AND m.is_moderated IS NOT TRUE

--- a/models/search_metadata.go
+++ b/models/search_metadata.go
@@ -297,9 +297,9 @@ WITH m AS (
                                    AND p.item_type_id = 2
                                    AND p.item_id = m.microcosm_id
                                    AND p.profile_id = $2
-           LEFT JOIN ignores i ON i.profile_id = $2
-                              AND i.item_type_id = 2
-                              AND i.item_id = m.microcosm_id
+           LEFT JOIN ignores_expanded i ON i.profile_id = $2
+                                       AND i.item_type_id = 2
+                                       AND i.item_id = m.microcosm_id
      WHERE m.site_id = $1
        AND m.is_deleted IS NOT TRUE
        AND m.is_moderated IS NOT TRUE

--- a/models/search_query.go
+++ b/models/search_query.go
@@ -668,8 +668,7 @@ SELECT microcosm_id
  WHERE path <@ (
            SELECT path
              FROM microcosms
-            WHERE site_id = 3
-              AND microcosm_id = ANY ($1::bigint[])
+            WHERE microcosm_id = ANY ($1::bigint[])
        );`,
 			microcosmIDs,
 		)
@@ -699,7 +698,9 @@ SELECT microcosm_id
 
 		sq.MicrocosmIDs = ids
 
-		valid = true
+		if len(sq.MicrocosmIDs) > 0 {
+			valid = true
+		}
 	}
 
 	// Build up our knowledge of what we're ignoring and what we are searching

--- a/models/search_query_test.go
+++ b/models/search_query_test.go
@@ -10,7 +10,7 @@ func TestSearchQueryParsing(t *testing.T) {
 	// Simple query
 	u, _ := url.Parse("https://test.microco.sm/api/v1/search?q=searchTerm&type=event&type=conversation")
 
-	sq := GetSearchQueryFromURL(*u)
+	sq := GetSearchQueryFromURL(1, *u, 1)
 
 	if len(sq.ItemTypesQuery) != 2 {
 		t.Errorf("Expected 2 itemTypes found %d", len(sq.ItemTypesQuery))
@@ -43,7 +43,7 @@ func TestSearchQueryParsing(t *testing.T) {
 	// Parse Q
 	u, _ = url.Parse("https://test.microco.sm/api/v1/search?q=searchTerm+type:event+type:conversation")
 
-	sq = GetSearchQueryFromURL(*u)
+	sq = GetSearchQueryFromURL(1, *u, 1)
 
 	if len(sq.ItemTypesQuery) != 2 {
 		t.Errorf("Expected 2 itemTypes found %d", len(sq.ItemTypesQuery))
@@ -76,7 +76,7 @@ func TestSearchQueryParsing(t *testing.T) {
 	// Mix of Q and Query
 	u, _ = url.Parse("https://test.microco.sm/api/v1/search?q=searchTerm+type:event+type:conversation&type=poll")
 
-	sq = GetSearchQueryFromURL(*u)
+	sq = GetSearchQueryFromURL(1, *u, 1)
 
 	if len(sq.ItemTypesQuery) != 3 {
 		t.Errorf("Expected 3 itemTypes found %d", len(sq.ItemTypesQuery))
@@ -115,7 +115,7 @@ func TestSearchQueryParsing(t *testing.T) {
 	// Mix of Q and Query
 	u, _ = url.Parse("https://test.microco.sm/api/v1/search?q=searchTerm&eventAfter=2012-06-07&type=event")
 
-	sq = GetSearchQueryFromURL(*u)
+	sq = GetSearchQueryFromURL(1, *u, 1)
 
 	control, _ := time.Parse("2006-01-02", "2012-06-07")
 	if sq.EventAfterTime.Unix() != control.Unix() {

--- a/models/sites.go
+++ b/models/sites.go
@@ -283,8 +283,8 @@ func (m *SiteType) Validate(exists bool) (int, error) {
 	return http.StatusOK, nil
 }
 
-// FetchProfileSummaries populates a partially populated site
-func (m *SiteType) FetchProfileSummaries() (int, error) {
+// Hydrate populates a partially populated site
+func (m *SiteType) Hydrate() (int, error) {
 
 	profile, status, err := GetProfileSummary(m.ID, m.Meta.CreatedByID)
 	if err != nil {
@@ -640,7 +640,6 @@ SELECT title
 
 // GetSite returns a site
 func GetSite(id int64) (SiteType, int, error) {
-
 	// Try cache
 	mcKey := fmt.Sprintf(mcSiteKeys[c.CacheDetail], id)
 	if val, ok := c.Get(mcKey, SiteType{}); ok {
@@ -648,7 +647,7 @@ func GetSite(id int64) (SiteType, int, error) {
 		// Site now caches the profile summaries as the benefits on performance
 		// are too great to do this every time as context.MakeContext for every
 		// controller uses a Site object
-		// m.FetchProfileSummaries()
+		// m.Hydrate()
 		return m, http.StatusOK, nil
 	}
 
@@ -739,7 +738,7 @@ SELECT s.site_id
 			h.GetLink("profile", "", h.ItemTypeProfile, 0),
 			h.LinkType{Rel: "legal", Href: "/api/v1/legal"},
 		}
-	m.FetchProfileSummaries()
+	m.Hydrate()
 
 	c.Set(mcKey, m, mcTTL)
 

--- a/models/summaries.go
+++ b/models/summaries.go
@@ -205,7 +205,13 @@ func GetSummary(
 		return summary, status, err
 
 	case h.ItemTypes[h.ItemTypeMicrocosm]:
-		summary, status, err := GetMicrocosmSummary(siteID, itemID, profileID)
+		fetchChildren := false
+		summary, status, err := GetMicrocosmSummary(
+			siteID,
+			itemID,
+			fetchChildren,
+			profileID,
+		)
 		if err != nil {
 			glog.Errorf(
 				"GetMicrocosmSummary(%d, %d, %d) %+v",

--- a/models/summaries.go
+++ b/models/summaries.go
@@ -205,11 +205,9 @@ func GetSummary(
 		return summary, status, err
 
 	case h.ItemTypes[h.ItemTypeMicrocosm]:
-		fetchChildren := false
 		summary, status, err := GetMicrocosmSummary(
 			siteID,
 			itemID,
-			fetchChildren,
 			profileID,
 		)
 		if err != nil {

--- a/models/updates.go
+++ b/models/updates.go
@@ -334,9 +334,9 @@ WITH m AS (
                                    AND p.item_type_id = 2
                                    AND p.item_id = m.microcosm_id
                                    AND p.profile_id = $2
-           LEFT JOIN ignores i ON i.profile_id = $2
-                              AND i.item_type_id = 2
-                              AND i.item_id = m.microcosm_id
+           LEFT JOIN ignores_expanded i ON i.profile_id = $2
+                                       AND i.item_type_id = 2
+                                       AND i.item_id = m.microcosm_id
      WHERE m.site_id = $1
        AND m.is_deleted IS NOT TRUE
        AND m.is_moderated IS NOT TRUE

--- a/models/updates.go
+++ b/models/updates.go
@@ -55,9 +55,9 @@ func (m *UpdateType) Validate(exists bool) (int, error) {
 	return http.StatusOK, nil
 }
 
-// FetchSummaries fetches profile/item summary for a update entry.
+// Hydrate fetches profile/item summary for a update entry.
 // Called post SELECT or post-GetFromCache
-func (m *UpdateType) FetchSummaries(siteID int64) (int, error) {
+func (m *UpdateType) Hydrate(siteID int64) (int, error) {
 
 	profile, status, err := GetSummary(
 		siteID,
@@ -251,7 +251,7 @@ func GetUpdate(
 	mcKey := fmt.Sprintf(mcUpdateKeys[c.CacheDetail], updateID)
 	if val, ok := c.Get(mcKey, UpdateType{}); ok {
 		m := val.(UpdateType)
-		m.FetchSummaries(siteID)
+		m.Hydrate(siteID)
 		return m, http.StatusOK, nil
 	}
 
@@ -300,7 +300,7 @@ SELECT update_id
 		return UpdateType{}, http.StatusInternalServerError, err
 	}
 	m.ItemType = itemType
-	m.FetchSummaries(siteID)
+	m.Hydrate(siteID)
 
 	c.Set(mcKey, m, mcTTL)
 	return m, http.StatusOK, nil

--- a/models/watchers.go
+++ b/models/watchers.go
@@ -419,9 +419,11 @@ SELECT watcher_id,
 			}
 			m.Item = item
 		} else {
+			fetchChildren := false
 			microcosm, _, err := GetMicrocosmSummary(
 				siteID,
 				m.ItemID,
+				fetchChildren,
 				m.ProfileID,
 			)
 			if err != nil {

--- a/models/watchers.go
+++ b/models/watchers.go
@@ -419,11 +419,9 @@ SELECT watcher_id,
 			}
 			m.Item = item
 		} else {
-			fetchChildren := false
 			microcosm, _, err := GetMicrocosmSummary(
 				siteID,
 				m.ItemID,
-				fetchChildren,
 				m.ProfileID,
 			)
 			if err != nil {

--- a/models/watchers.go
+++ b/models/watchers.go
@@ -265,9 +265,9 @@ SELECT COALESCE(w.watcher_id, 0) AS watcher_id
   LEFT JOIN watchers w ON w.item_type_id = f.item_type_id
                       AND w.item_id = f.item_id
                       AND w.profile_id = $3
-  LEFT JOIN ignores i ON i.item_type_id = f.item_type_id
-                     AND i.item_id = f.item_id
-                     AND i.profile_id = $3
+  LEFT JOIN ignores_expanded i ON i.item_type_id = f.item_type_id
+                              AND i.item_id = f.item_id
+                              AND i.profile_id = $3
  WHERE f.item_type_id = $1
    AND f.item_id = $2
  ORDER BY 1 DESC

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -99,6 +99,7 @@ var (
 		"/api/v1/{type:microcosms}/{microcosm_id:[0-9]+}/roles/{role_id:[0-9]+}/criteria":                       controller.RoleCriteriaHandler,
 		"/api/v1/{type:microcosms}/{microcosm_id:[0-9]+}/roles/{role_id:[0-9]+}/criteria/{criterion_id:[0-9]+}": controller.RoleCriterionHandler,
 		"/api/v1/{type:microcosms}/{microcosm_id:[0-9]+}/roles/{role_id:[0-9]+}/members":                        controller.RoleMembersHandler,
+		"/api/v1/{type:microcosms}/tree":                                                                        controller.MicrocosmsTreeHandler,
 
 		"/api/v1/permission": controller.PermissionHandler,
 


### PR DESCRIPTION
Instead of the site listing all microcosms at the top level, we now have a single forum that is the parent to all other forums.

The introduction of this allows for forums to also contain other forums, and for the structure of a site to now be hierarchical as well as retaining the option to describe a site as a flat list.

This required breadcrumbs to be changed, permissions to be changed, ignores to be changed, has_unread to be changed.

Also included in these commits are some admin capabilities to view email addresses, search by an email address and so forth.