### PR TITLE
Canonical email

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,3 +63,6 @@ fetch:
 	-gvt fetch -no-recurse github.com/xtgo/uuid
 	-gvt fetch -no-recurse golang.org/x/net/html
 	-gvt fetch -no-recurse golang.org/x/oauth2
+
+update:
+	-gvt update -all

--- a/db/migrations/20160831112556_canonical_email.sql
+++ b/db/migrations/20160831112556_canonical_email.sql
@@ -1,0 +1,224 @@
+
+-- +goose Up
+-- SQL in section 'Up' is executed when this migration is applied
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION canonical_email(
+	email varchar
+)
+  RETURNS varchar AS
+$BODY$
+DECLARE
+canonicalised varchar;
+localpart varchar;
+domainpart varchar;
+BEGIN
+
+-- Important to note that this function does not validate an email address, it
+-- merely produces a canonical form of the email address.
+
+-- lowercase
+canonicalised = LOWER(email);
+
+-- localpart is the user@ part
+localpart = SPLIT_PART(canonicalised, '@', 1);
+
+-- ignore dots in the user part
+localpart = REPLACE(localpart, '.', '');
+
+-- ignore everything after + in the user part
+localpart = SPLIT_PART(localpart, '+', 1);
+
+-- strip comment prefix
+IF localpart ~ '^\([^(]*\).+' THEN
+	localpart = regexp_replace(localpart, '^\([^(]*\)', '');
+END IF;
+
+-- strip comment suffix
+IF localpart ~ '.+\([^(]*\)$' THEN
+	localpart = regexp_replace(localpart, '\([^(]*\)$', '');
+END IF;
+
+-- domainpart is the @domain part
+domainpart = SPLIT_PART(canonicalised, '@', 2);
+
+CASE domainpart
+
+-- Apple
+WHEN 'mac.com' THEN
+	domainpart = 'icloud.com';
+WHEN 'me.com' THEN
+	domainpart = 'icloud.com';
+
+-- BT
+WHEN 'btopenworld.com' THEN
+	domainpart = 'btinternet.com';
+
+-- GMX
+WHEN 'gmx.at' THEN
+	domainpart = 'gmx.de';
+WHEN 'gmx.ch' THEN
+	domainpart = 'gmx.de';
+WHEN 'gmx.com' THEN
+	domainpart = 'gmx.de';
+WHEN 'gmx.co.uk' THEN
+	domainpart = 'gmx.de';
+WHEN 'gmx.fr' THEN
+	domainpart = 'gmx.de';
+WHEN 'gmx.li' THEN
+	domainpart = 'gmx.de';
+WHEN 'gmx.net' THEN
+	domainpart = 'gmx.de';
+WHEN 'gmx.org' THEN
+	domainpart = 'gmx.de';
+WHEN 'gmx.us' THEN
+	domainpart = 'gmx.de';
+
+-- Google
+WHEN 'googlemail.com' THEN
+	domainpart = 'gmail.com';
+
+-- Outlook
+WHEN 'hotmail.be' THEN
+	domainpart = 'outlook.com';
+WHEN 'hotmail.co.jp' THEN
+	domainpart = 'outlook.com';
+WHEN 'hotmail.com' THEN
+	domainpart = 'outlook.com';
+WHEN 'hotmail.com.au' THEN
+	domainpart = 'outlook.com';
+WHEN 'hotmail.com.tw' THEN
+	domainpart = 'outlook.com';
+WHEN 'hotmail.con' THEN
+	domainpart = 'outlook.com';
+WHEN 'hotmail.co.nz' THEN
+	domainpart = 'outlook.com';
+WHEN 'hotmail.co.uk' THEN
+	domainpart = 'outlook.com';
+WHEN 'hotmail.de' THEN
+	domainpart = 'outlook.com';
+WHEN 'hotmail.es' THEN
+	domainpart = 'outlook.com';
+WHEN 'hotmail.fi' THEN
+	domainpart = 'outlook.com';
+WHEN 'hotmail.fr' THEN
+	domainpart = 'outlook.com';
+WHEN 'hotmail.it' THEN
+	domainpart = 'outlook.com';
+WHEN 'hotmail.lt' THEN
+	domainpart = 'outlook.com';
+WHEN 'hotmail.lv' THEN
+	domainpart = 'outlook.com';
+WHEN 'hotmail.nl' THEN
+	domainpart = 'outlook.com';
+WHEN 'hotmail.no' THEN
+	domainpart = 'outlook.com';
+WHEN 'hotmail.org' THEN
+	domainpart = 'outlook.com';
+WHEN 'hotmail.se' THEN
+	domainpart = 'outlook.com';
+WHEN 'hotmail.sg' THEN
+	domainpart = 'outlook.com';
+WHEN 'live.com' THEN
+	domainpart = 'outlook.com';
+WHEN 'live.co.uk' THEN
+	domainpart = 'outlook.com';
+WHEN 'msn.com' THEN
+	domainpart = 'outlook.com';
+WHEN 'passport.com' THEN
+	domainpart = 'outlook.com';
+
+--Virgin
+WHEN 'virgin.net' THEN
+	domainpart = 'virginmedia.com';
+
+-- Yahoo
+WHEN 'yahoo.ca' THEN
+	domainpart = 'yahoo.com';
+WHEN 'yahoo.co.id' THEN
+	domainpart = 'yahoo.com';
+WHEN 'yahoo.co.in' THEN
+	domainpart = 'yahoo.com';
+WHEN 'yahoo.co.jp' THEN
+	domainpart = 'yahoo.com';
+WHEN 'yahoo.com.ar' THEN
+	domainpart = 'yahoo.com';
+WHEN 'yahoo.com.au' THEN
+	domainpart = 'yahoo.com';
+WHEN 'yahoo.com.br' THEN
+	domainpart = 'yahoo.com';
+WHEN 'yahoo.com.cn' THEN
+	domainpart = 'yahoo.com';
+WHEN 'yahoo.com.hk' THEN
+	domainpart = 'yahoo.com';
+WHEN 'yahoo.com.mx' THEN
+	domainpart = 'yahoo.com';
+WHEN 'yahoo.com.my' THEN
+	domainpart = 'yahoo.com';
+WHEN 'yahoo.com.ph' THEN
+	domainpart = 'yahoo.com';
+WHEN 'yahoo.com.sg' THEN
+	domainpart = 'yahoo.com';
+WHEN 'yahoo.com.tw' THEN
+	domainpart = 'yahoo.com';
+WHEN 'yahoo.com.uk' THEN
+	domainpart = 'yahoo.com';
+WHEN 'yahoo.co.nz' THEN
+	domainpart = 'yahoo.com';
+WHEN 'yahoo.co.uk' THEN
+	domainpart = 'yahoo.com';
+WHEN 'yahoo.de' THEN
+	domainpart = 'yahoo.com';
+WHEN 'yahoo.dk' THEN
+	domainpart = 'yahoo.com';
+WHEN 'yahoo.es' THEN
+	domainpart = 'yahoo.com';
+WHEN 'yahoo.fr' THEN
+	domainpart = 'yahoo.com';
+WHEN 'yahoo.gr' THEN
+	domainpart = 'yahoo.com';
+WHEN 'yahoo.ie' THEN
+	domainpart = 'yahoo.com';
+WHEN 'yahoo.it' THEN
+	domainpart = 'yahoo.com';
+WHEN 'yahoomail.com' THEN
+	domainpart = 'yahoo.com';
+WHEN 'yahoo.no' THEN
+	domainpart = 'yahoo.com';
+WHEN 'yahoo.pl' THEN
+	domainpart = 'yahoo.com';
+WHEN 'yahoo.ro' THEN
+	domainpart = 'yahoo.com';
+WHEN 'yahoo.se' THEN
+	domainpart = 'yahoo.com';
+
+ELSE
+
+END CASE;
+
+canonicalised = localpart || '@' || domainpart;
+
+RETURN canonicalised;
+END;
+$BODY$
+  LANGUAGE 'plpgsql' STABLE
+  COST 100;
+-- +goose StatementEnd
+
+ALTER FUNCTION canonical_email(varchar) OWNER TO microcosm;
+
+ALTER TABLE users ADD COLUMN canonical_email character varying(254);
+
+COMMENT ON COLUMN users.canonical_email IS 'The canonical representation of an email for the purpose of uniquely identifying accounts.
+
+The email column is the address to which we send email (and is the first version of the email we see for a customer), whereas the canonical email is the address by which we identify a user.';
+
+UPDATE users u
+   SET canonical_email = canonical_email(email)
+ WHERE canonical_email IS NULL;
+
+-- +goose Down
+-- SQL section 'Down' is executed when this migration is rolled back
+
+ALTER TABLE users DROP COLUMN canonical_email;
+DROP FUNCTION canonical_email(varchar);

--- a/db/migrations/20160831112556_canonical_email.sql
+++ b/db/migrations/20160831112556_canonical_email.sql
@@ -78,56 +78,6 @@ WHEN 'gmx.us' THEN
 WHEN 'googlemail.com' THEN
 	domainpart = 'gmail.com';
 
--- Outlook
-WHEN 'hotmail.be' THEN
-	domainpart = 'outlook.com';
-WHEN 'hotmail.co.jp' THEN
-	domainpart = 'outlook.com';
-WHEN 'hotmail.com' THEN
-	domainpart = 'outlook.com';
-WHEN 'hotmail.com.au' THEN
-	domainpart = 'outlook.com';
-WHEN 'hotmail.com.tw' THEN
-	domainpart = 'outlook.com';
-WHEN 'hotmail.con' THEN
-	domainpart = 'outlook.com';
-WHEN 'hotmail.co.nz' THEN
-	domainpart = 'outlook.com';
-WHEN 'hotmail.co.uk' THEN
-	domainpart = 'outlook.com';
-WHEN 'hotmail.de' THEN
-	domainpart = 'outlook.com';
-WHEN 'hotmail.es' THEN
-	domainpart = 'outlook.com';
-WHEN 'hotmail.fi' THEN
-	domainpart = 'outlook.com';
-WHEN 'hotmail.fr' THEN
-	domainpart = 'outlook.com';
-WHEN 'hotmail.it' THEN
-	domainpart = 'outlook.com';
-WHEN 'hotmail.lt' THEN
-	domainpart = 'outlook.com';
-WHEN 'hotmail.lv' THEN
-	domainpart = 'outlook.com';
-WHEN 'hotmail.nl' THEN
-	domainpart = 'outlook.com';
-WHEN 'hotmail.no' THEN
-	domainpart = 'outlook.com';
-WHEN 'hotmail.org' THEN
-	domainpart = 'outlook.com';
-WHEN 'hotmail.se' THEN
-	domainpart = 'outlook.com';
-WHEN 'hotmail.sg' THEN
-	domainpart = 'outlook.com';
-WHEN 'live.com' THEN
-	domainpart = 'outlook.com';
-WHEN 'live.co.uk' THEN
-	domainpart = 'outlook.com';
-WHEN 'msn.com' THEN
-	domainpart = 'outlook.com';
-WHEN 'passport.com' THEN
-	domainpart = 'outlook.com';
-
 --Virgin
 WHEN 'virgin.net' THEN
 	domainpart = 'virginmedia.com';
@@ -138,8 +88,6 @@ WHEN 'yahoo.ca' THEN
 WHEN 'yahoo.co.id' THEN
 	domainpart = 'yahoo.com';
 WHEN 'yahoo.co.in' THEN
-	domainpart = 'yahoo.com';
-WHEN 'yahoo.co.jp' THEN
 	domainpart = 'yahoo.com';
 WHEN 'yahoo.com.ar' THEN
 	domainpart = 'yahoo.com';

--- a/vendor/github.com/gorilla/mux/mux.go
+++ b/vendor/github.com/gorilla/mux/mux.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"path"
 	"regexp"
+	"strings"
 )
 
 // NewRouter returns a new router instance.
@@ -52,6 +53,8 @@ type Router struct {
 	// This has no effect when go1.7+ is used, since the context is stored
 	// on the request itself.
 	KeepContext bool
+	// see Router.UseEncodedPath(). This defines a flag for all routes.
+	useEncodedPath bool
 }
 
 // Match matches registered routes against the request.
@@ -76,8 +79,12 @@ func (r *Router) Match(req *http.Request, match *RouteMatch) bool {
 // mux.Vars(request).
 func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	if !r.skipClean {
+		path := req.URL.Path
+		if r.useEncodedPath {
+			path = getPath(req)
+		}
 		// Clean path to canonical form and redirect.
-		if p := cleanPath(req.URL.Path); p != req.URL.Path {
+		if p := cleanPath(path); p != path {
 
 			// Added 3 lines (Philip Schlump) - It was dropping the query string and #whatever from query.
 			// This matches with fix in go 1.2 r.c. 4 for same problem.  Go Issue:
@@ -150,6 +157,21 @@ func (r *Router) SkipClean(value bool) *Router {
 	return r
 }
 
+// UseEncodedPath tells the router to match the encoded original path
+// to the routes.
+// For eg. "/path/foo%2Fbar/to" will match the path "/path/{var}/to".
+// This behavior has the drawback of needing to match routes against
+// r.RequestURI instead of r.URL.Path. Any modifications (such as http.StripPrefix)
+// to r.URL.Path will not affect routing when this flag is on and thus may
+// induce unintended behavior.
+//
+// If not called, the router will match the unencoded path to the routes.
+// For eg. "/path/foo%2Fbar/to" will match the path "/path/foo/bar/to"
+func (r *Router) UseEncodedPath() *Router {
+	r.useEncodedPath = true
+	return r
+}
+
 // ----------------------------------------------------------------------------
 // parentRoute
 // ----------------------------------------------------------------------------
@@ -187,7 +209,7 @@ func (r *Router) buildVars(m map[string]string) map[string]string {
 
 // NewRoute registers an empty route.
 func (r *Router) NewRoute() *Route {
-	route := &Route{parent: r, strictSlash: r.strictSlash, skipClean: r.skipClean}
+	route := &Route{parent: r, strictSlash: r.strictSlash, skipClean: r.skipClean, useEncodedPath: r.useEncodedPath}
 	r.routes = append(r.routes, route)
 	return route
 }
@@ -357,6 +379,28 @@ func setCurrentRoute(r *http.Request, val interface{}) *http.Request {
 // ----------------------------------------------------------------------------
 // Helpers
 // ----------------------------------------------------------------------------
+
+// getPath returns the escaped path if possible; doing what URL.EscapedPath()
+// which was added in go1.5 does
+func getPath(req *http.Request) string {
+	if req.RequestURI != "" {
+		// Extract the path from RequestURI (which is escaped unlike URL.Path)
+		// as detailed here as detailed in https://golang.org/pkg/net/url/#URL
+		// for < 1.5 server side workaround
+		// http://localhost/path/here?v=1 -> /path/here
+		path := req.RequestURI
+		path = strings.TrimPrefix(path, req.URL.Scheme+`://`)
+		path = strings.TrimPrefix(path, req.URL.Host)
+		if i := strings.LastIndex(path, "?"); i > -1 {
+			path = path[:i]
+		}
+		if i := strings.LastIndex(path, "#"); i > -1 {
+			path = path[:i]
+		}
+		return path
+	}
+	return req.URL.Path
+}
 
 // cleanPath returns the canonical path for p, eliminating . and .. elements.
 // Borrowed from the net/http package.

--- a/vendor/github.com/gorilla/mux/regexp.go
+++ b/vendor/github.com/gorilla/mux/regexp.go
@@ -24,7 +24,7 @@ import (
 // Previously we accepted only Python-like identifiers for variable
 // names ([a-zA-Z_][a-zA-Z0-9_]*), but currently the only restriction is that
 // name and pattern can't be empty, and names can't contain a colon.
-func newRouteRegexp(tpl string, matchHost, matchPrefix, matchQuery, strictSlash bool) (*routeRegexp, error) {
+func newRouteRegexp(tpl string, matchHost, matchPrefix, matchQuery, strictSlash, useEncodedPath bool) (*routeRegexp, error) {
 	// Check if it is well-formed.
 	idxs, errBraces := braceIndices(tpl)
 	if errBraces != nil {
@@ -111,14 +111,15 @@ func newRouteRegexp(tpl string, matchHost, matchPrefix, matchQuery, strictSlash 
 	}
 	// Done!
 	return &routeRegexp{
-		template:    template,
-		matchHost:   matchHost,
-		matchQuery:  matchQuery,
-		strictSlash: strictSlash,
-		regexp:      reg,
-		reverse:     reverse.String(),
-		varsN:       varsN,
-		varsR:       varsR,
+		template:       template,
+		matchHost:      matchHost,
+		matchQuery:     matchQuery,
+		strictSlash:    strictSlash,
+		useEncodedPath: useEncodedPath,
+		regexp:         reg,
+		reverse:        reverse.String(),
+		varsN:          varsN,
+		varsR:          varsR,
 	}, nil
 }
 
@@ -133,6 +134,9 @@ type routeRegexp struct {
 	matchQuery bool
 	// The strictSlash value defined on the route, but disabled if PathPrefix was used.
 	strictSlash bool
+	// Determines whether to use encoded path from getPath function or unencoded
+	// req.URL.Path for path matching
+	useEncodedPath bool
 	// Expanded regexp.
 	regexp *regexp.Regexp
 	// Reverse template.
@@ -149,8 +153,11 @@ func (r *routeRegexp) Match(req *http.Request, match *RouteMatch) bool {
 		if r.matchQuery {
 			return r.matchQueryString(req)
 		}
-
-		return r.regexp.MatchString(req.URL.Path)
+		path := req.URL.Path
+		if r.useEncodedPath {
+			path = getPath(req)
+		}
+		return r.regexp.MatchString(path)
 	}
 
 	return r.regexp.MatchString(getHost(req))
@@ -253,14 +260,18 @@ func (v *routeRegexpGroup) setMatch(req *http.Request, m *RouteMatch, r *Route) 
 			extractVars(host, matches, v.host.varsN, m.Vars)
 		}
 	}
+	path := req.URL.Path
+	if r.useEncodedPath {
+		path = getPath(req)
+	}
 	// Store path variables.
 	if v.path != nil {
-		matches := v.path.regexp.FindStringSubmatchIndex(req.URL.Path)
+		matches := v.path.regexp.FindStringSubmatchIndex(path)
 		if len(matches) > 0 {
-			extractVars(req.URL.Path, matches, v.path.varsN, m.Vars)
+			extractVars(path, matches, v.path.varsN, m.Vars)
 			// Check if we should redirect.
 			if v.path.strictSlash {
-				p1 := strings.HasSuffix(req.URL.Path, "/")
+				p1 := strings.HasSuffix(path, "/")
 				p2 := strings.HasSuffix(v.path.template, "/")
 				if p1 != p2 {
 					u, _ := url.Parse(req.URL.String())
@@ -299,14 +310,7 @@ func getHost(r *http.Request) string {
 }
 
 func extractVars(input string, matches []int, names []string, output map[string]string) {
-	matchesCount := 0
-	prevEnd := -1
-	for i := 2; i < len(matches) && matchesCount < len(names); i += 2 {
-		if prevEnd < matches[i+1] {
-			value := input[matches[i]:matches[i+1]]
-			output[names[matchesCount]] = value
-			prevEnd = matches[i+1]
-			matchesCount++
-		}
+	for i, name := range names {
+		output[name] = input[matches[2*i+2]:matches[2*i+3]]
 	}
 }

--- a/vendor/github.com/gorilla/mux/route.go
+++ b/vendor/github.com/gorilla/mux/route.go
@@ -29,6 +29,8 @@ type Route struct {
 	// If true, when the path pattern is "/path//to", accessing "/path//to"
 	// will not redirect
 	skipClean bool
+	// If true, "/path/foo%2Fbar/to" will match the path "/path/{var}/to"
+	useEncodedPath bool
 	// If true, this route never matches: it is only used to build URLs.
 	buildOnly bool
 	// The name used to build URLs.
@@ -158,7 +160,7 @@ func (r *Route) addRegexpMatcher(tpl string, matchHost, matchPrefix, matchQuery 
 			tpl = strings.TrimRight(r.regexp.path.template, "/") + tpl
 		}
 	}
-	rr, err := newRouteRegexp(tpl, matchHost, matchPrefix, matchQuery, r.strictSlash)
+	rr, err := newRouteRegexp(tpl, matchHost, matchPrefix, matchQuery, r.strictSlash, r.useEncodedPath)
 	if err != nil {
 		return err
 	}

--- a/vendor/github.com/microcosm-cc/bluemonday/policy.go
+++ b/vendor/github.com/microcosm-cc/bluemonday/policy.go
@@ -50,6 +50,10 @@ type Policy struct {
 	// Allows the <!DOCTYPE > tag to exist in the sanitized document
 	allowDocType bool
 
+	// If true then we add spaces when stripping tags, specifically the closing
+	// tag is replaced by a space character.
+	addSpaces bool
+
 	// When true, add rel="nofollow" to HTML anchors
 	requireNoFollow bool
 
@@ -380,6 +384,23 @@ func (p *Policy) AllowDocType(allow bool) *Policy {
 	return p
 }
 
+// AddSpaceWhenStrippingTag states whether to add a single space " " when
+// removing tags that are not whitelisted by the policy.
+//
+// This is useful if you expect to strip tags in dense markup and may lose the
+// value of whitespace.
+//
+// For example: "<p>Hello</p><p>World</p>"" would be sanitized to "HelloWorld"
+// with the default value of false, but you may wish to sanitize this to
+// " Hello  World " by setting AddSpaceWhenStrippingTag to true as this would
+// retain the intent of the text.
+func (p *Policy) AddSpaceWhenStrippingTag(allow bool) *Policy {
+
+	p.addSpaces = allow
+
+	return p
+}
+
 // SkipElementsContent adds the HTML elements whose tags is needed to be removed
 // with it's content.
 func (p *Policy) SkipElementsContent(names ...string) *Policy {
@@ -392,6 +413,19 @@ func (p *Policy) SkipElementsContent(names ...string) *Policy {
 		if _, ok := p.setOfElementsToSkipContent[element]; !ok {
 			p.setOfElementsToSkipContent[element] = struct{}{}
 		}
+	}
+
+	return p
+}
+
+// AllowElementsContent marks the HTML elements whose content should be
+// retained after removing the tag.
+func (p *Policy) AllowElementsContent(names ...string) *Policy {
+
+	p.init()
+
+	for _, element := range names {
+		delete(p.setOfElementsToSkipContent, strings.ToLower(element))
 	}
 
 	return p

--- a/vendor/github.com/microcosm-cc/bluemonday/sanitize.go
+++ b/vendor/github.com/microcosm-cc/bluemonday/sanitize.go
@@ -130,6 +130,9 @@ func (p *Policy) sanitize(r io.Reader) *bytes.Buffer {
 					skipElementContent = true
 					skippingElementsCount++
 				}
+				if p.addSpaces {
+					buff.WriteString(" ")
+				}
 				break
 			}
 
@@ -141,6 +144,9 @@ func (p *Policy) sanitize(r io.Reader) *bytes.Buffer {
 				if !p.allowNoAttrs(token.Data) {
 					skipClosingTag = true
 					closingTagToSkipStack = append(closingTagToSkipStack, token.Data)
+					if p.addSpaces {
+						buff.WriteString(" ")
+					}
 					break
 				}
 			}
@@ -156,6 +162,9 @@ func (p *Policy) sanitize(r io.Reader) *bytes.Buffer {
 				if len(closingTagToSkipStack) == 0 {
 					skipClosingTag = false
 				}
+				if p.addSpaces {
+					buff.WriteString(" ")
+				}
 				break
 			}
 
@@ -165,6 +174,9 @@ func (p *Policy) sanitize(r io.Reader) *bytes.Buffer {
 					if skippingElementsCount == 0 {
 						skipElementContent = false
 					}
+				}
+				if p.addSpaces {
+					buff.WriteString(" ")
 				}
 				break
 			}
@@ -177,6 +189,9 @@ func (p *Policy) sanitize(r io.Reader) *bytes.Buffer {
 
 			aps, ok := p.elsAndAttrs[token.Data]
 			if !ok {
+				if p.addSpaces {
+					buff.WriteString(" ")
+				}
 				break
 			}
 
@@ -185,6 +200,9 @@ func (p *Policy) sanitize(r io.Reader) *bytes.Buffer {
 			}
 
 			if len(token.Attr) == 0 && !p.allowNoAttrs(token.Data) {
+				if p.addSpaces {
+					buff.WriteString(" ")
+				}
 				break
 			}
 
@@ -339,8 +357,10 @@ func (p *Policy) sanitizeAttrs(
 				}
 
 				if hrefFound {
-					var noFollowFound bool
-					var targetFound bool
+					var (
+						noFollowFound    bool
+						targetBlankFound bool
+					)
 
 					addNoFollow := (p.requireNoFollow ||
 						externalLink && p.requireNoFollowFullyQualifiedLinks)
@@ -357,36 +377,32 @@ func (p *Policy) sanitizeAttrs(
 							if strings.Contains(htmlAttr.Val, "nofollow") {
 								noFollowFound = true
 								tmpAttrs = append(tmpAttrs, htmlAttr)
+								appended = true
 							} else {
 								htmlAttr.Val += " nofollow"
 								noFollowFound = true
 								tmpAttrs = append(tmpAttrs, htmlAttr)
+								appended = true
 							}
-
-							appended = true
 						}
 
-						if elementName == "a" &&
-							htmlAttr.Key == "target" &&
-							addTargetBlank {
-
-							if strings.Contains(htmlAttr.Val, "_blank") {
-								targetFound = true
-								tmpAttrs = append(tmpAttrs, htmlAttr)
-							} else {
-								htmlAttr.Val = "_blank"
-								targetFound = true
-								tmpAttrs = append(tmpAttrs, htmlAttr)
+						if elementName == "a" && htmlAttr.Key == "target" {
+							if htmlAttr.Val == "_blank" {
+								targetBlankFound = true
 							}
-
-							appended = true
+							if addTargetBlank && !targetBlankFound {
+								htmlAttr.Val = "_blank"
+								targetBlankFound = true
+								tmpAttrs = append(tmpAttrs, htmlAttr)
+								appended = true
+							}
 						}
 
 						if !appended {
 							tmpAttrs = append(tmpAttrs, htmlAttr)
 						}
 					}
-					if noFollowFound || targetFound {
+					if noFollowFound || targetBlankFound {
 						cleanAttrs = tmpAttrs
 					}
 
@@ -397,11 +413,62 @@ func (p *Policy) sanitizeAttrs(
 						cleanAttrs = append(cleanAttrs, rel)
 					}
 
-					if elementName == "a" && addTargetBlank && !targetFound {
+					if elementName == "a" && addTargetBlank && !targetBlankFound {
 						rel := html.Attribute{}
 						rel.Key = "target"
 						rel.Val = "_blank"
+						targetBlankFound = true
 						cleanAttrs = append(cleanAttrs, rel)
+					}
+
+					if targetBlankFound {
+						// target="_blank" has a security risk that allows the
+						// opened window/tab to issue JavaScript calls against
+						// window.opener, which in effect allow the destination
+						// of the link to control the source:
+						// https://dev.to/ben/the-targetblank-vulnerability-by-example
+						//
+						// To mitigate this risk, we need to add a specific rel
+						// attribute if it is not already present.
+						// rel="noopener"
+						//
+						// Unfortunately this is processing the rel twice (we
+						// already looked at it earlier ^^) as we cannot be sure
+						// of the ordering of the href and rel, and whether we
+						// have fully satisfied that we need to do this. This
+						// double processing only happens *if* target="_blank"
+						// is true.
+						var noOpenerAdded bool
+						tmpAttrs := []html.Attribute{}
+						for _, htmlAttr := range cleanAttrs {
+							var appended bool
+							if htmlAttr.Key == "rel" {
+								if strings.Contains(htmlAttr.Val, "noopener") {
+									noOpenerAdded = true
+									tmpAttrs = append(tmpAttrs, htmlAttr)
+								} else {
+									htmlAttr.Val += " noopener"
+									noOpenerAdded = true
+									tmpAttrs = append(tmpAttrs, htmlAttr)
+								}
+
+								appended = true
+							}
+							if !appended {
+								tmpAttrs = append(tmpAttrs, htmlAttr)
+							}
+						}
+						if noOpenerAdded {
+							cleanAttrs = tmpAttrs
+						} else {
+							// rel attr was not found, or else noopener would
+							// have been added already
+							rel := html.Attribute{}
+							rel.Key = "rel"
+							rel.Val = "noopener"
+							cleanAttrs = append(cleanAttrs, rel)
+						}
+
 					}
 				}
 			default:

--- a/vendor/golang.org/x/oauth2/google/google.go
+++ b/vendor/golang.org/x/oauth2/google/google.go
@@ -89,6 +89,7 @@ func JWTConfigFromJSON(jsonKey []byte, scope ...string) (*jwt.Config, error) {
 		Email        string `json:"client_email"`
 		PrivateKey   string `json:"private_key"`
 		PrivateKeyID string `json:"private_key_id"`
+		TokenURL     string `json:"token_uri"`
 	}
 	if err := json.Unmarshal(jsonKey, &key); err != nil {
 		return nil, err
@@ -98,7 +99,10 @@ func JWTConfigFromJSON(jsonKey []byte, scope ...string) (*jwt.Config, error) {
 		PrivateKey:   []byte(key.PrivateKey),
 		PrivateKeyID: key.PrivateKeyID,
 		Scopes:       scope,
-		TokenURL:     JWTTokenURL,
+		TokenURL:     key.TokenURL,
+	}
+	if config.TokenURL == "" {
+		config.TokenURL = JWTTokenURL
 	}
 	return config, nil
 }

--- a/vendor/golang.org/x/oauth2/heroku/heroku.go
+++ b/vendor/golang.org/x/oauth2/heroku/heroku.go
@@ -1,0 +1,16 @@
+// Copyright 2016 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package heroku provides constants for using OAuth2 to access Heroku.
+package heroku // import "golang.org/x/oauth2/heroku"
+
+import (
+	"golang.org/x/oauth2"
+)
+
+// Endpoint is Heroku's OAuth 2.0 endpoint.
+var Endpoint = oauth2.Endpoint{
+	AuthURL:  "https://id.heroku.com/oauth/authorize",
+	TokenURL: "https://id.heroku.com/oauth/token",
+}

--- a/vendor/golang.org/x/oauth2/jws/jws.go
+++ b/vendor/golang.org/x/oauth2/jws/jws.go
@@ -2,8 +2,16 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// Package jws provides encoding and decoding utilities for
-// signed JWS messages.
+// Package jws provides a partial implementation
+// of JSON Web Signature encoding and decoding.
+// It exists to support the golang.org/x/oauth2 package.
+//
+// See RFC 7515.
+//
+// Deprecated: this package is not intended for public use and might be
+// removed in the future. It exists for internal use only.
+// Please switch to another JWS package or copy this package into your own
+// source tree.
 package jws // import "golang.org/x/oauth2/jws"
 
 import (

--- a/vendor/golang.org/x/oauth2/oauth2.go
+++ b/vendor/golang.org/x/oauth2/oauth2.go
@@ -21,6 +21,8 @@ import (
 
 // NoContext is the default context you should supply if not using
 // your own context.Context (see https://golang.org/x/net/context).
+//
+// Deprecated: Use context.Background() or context.TODO() instead.
 var NoContext = context.TODO()
 
 // RegisterBrokenAuthHeaderProvider registers an OAuth2 server

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -46,7 +46,7 @@
 			"importpath": "github.com/gorilla/mux",
 			"repository": "https://github.com/gorilla/mux",
 			"vcs": "git",
-			"revision": "cf79e51a62d8219d52060dfc1b4e810414ba2d15",
+			"revision": "0a192a193177452756c362c20087ddafcf6829c4",
 			"branch": "master",
 			"notests": true
 		},
@@ -54,7 +54,7 @@
 			"importpath": "github.com/lib/pq",
 			"repository": "https://github.com/lib/pq",
 			"vcs": "git",
-			"revision": "80f8150043c80fb52dee6bc863a709cdac7ec8f8",
+			"revision": "50761b0867bd1d9d069276790bcd4a3bccf2324a",
 			"branch": "master",
 			"notests": true
 		},
@@ -62,7 +62,7 @@
 			"importpath": "github.com/microcosm-cc/bluemonday",
 			"repository": "https://github.com/microcosm-cc/bluemonday",
 			"vcs": "git",
-			"revision": "9dc199233bf72cc1aad9b61f73daf2f0075b9ee4",
+			"revision": "7d0cad0ac7ef5e3afd74816444b44b56327422a4",
 			"branch": "master",
 			"notests": true
 		},
@@ -178,7 +178,7 @@
 			"importpath": "golang.org/x/image/bmp",
 			"repository": "https://go.googlesource.com/image",
 			"vcs": "git",
-			"revision": "9f8d0d45877da31f672995d10677ae6a586e31a5",
+			"revision": "714f2e47f73aac52208d4f4260e4ba79358a9c28",
 			"branch": "master",
 			"path": "/bmp",
 			"notests": true
@@ -187,7 +187,7 @@
 			"importpath": "golang.org/x/image/tiff",
 			"repository": "https://go.googlesource.com/image",
 			"vcs": "git",
-			"revision": "9f8d0d45877da31f672995d10677ae6a586e31a5",
+			"revision": "714f2e47f73aac52208d4f4260e4ba79358a9c28",
 			"branch": "master",
 			"path": "tiff",
 			"notests": true
@@ -196,7 +196,7 @@
 			"importpath": "golang.org/x/net/html",
 			"repository": "https://go.googlesource.com/net",
 			"vcs": "git",
-			"revision": "7394c112eae4dba7e96bfcfe738e6373d61772b4",
+			"revision": "1358eff22f0dd0c54fc521042cc607f6ff4b531a",
 			"branch": "master",
 			"path": "/html",
 			"notests": true
@@ -205,7 +205,7 @@
 			"importpath": "golang.org/x/oauth2",
 			"repository": "https://go.googlesource.com/oauth2",
 			"vcs": "git",
-			"revision": "3b966c7f301c0c71c53d94dc632a62df0a682cd7",
+			"revision": "3c3a985cb79f52a3190fbc056984415ca6763d01",
 			"branch": "master",
 			"notests": true
 		},
@@ -213,7 +213,7 @@
 			"importpath": "golang.org/x/text/encoding",
 			"repository": "https://go.googlesource.com/text",
 			"vcs": "git",
-			"revision": "d69c40b4be55797923cec7457fac7a244d91a9b6",
+			"revision": "ceefd2213ed29504fff30155163c8f59827734f3",
 			"branch": "master",
 			"path": "encoding",
 			"notests": true
@@ -222,7 +222,7 @@
 			"importpath": "golang.org/x/text/internal/gen",
 			"repository": "https://go.googlesource.com/text",
 			"vcs": "git",
-			"revision": "d69c40b4be55797923cec7457fac7a244d91a9b6",
+			"revision": "ceefd2213ed29504fff30155163c8f59827734f3",
 			"branch": "master",
 			"path": "internal/gen",
 			"notests": true
@@ -231,7 +231,7 @@
 			"importpath": "golang.org/x/text/internal/tag",
 			"repository": "https://go.googlesource.com/text",
 			"vcs": "git",
-			"revision": "d69c40b4be55797923cec7457fac7a244d91a9b6",
+			"revision": "ceefd2213ed29504fff30155163c8f59827734f3",
 			"branch": "master",
 			"path": "internal/tag",
 			"notests": true
@@ -240,7 +240,7 @@
 			"importpath": "golang.org/x/text/internal/utf8internal",
 			"repository": "https://go.googlesource.com/text",
 			"vcs": "git",
-			"revision": "d69c40b4be55797923cec7457fac7a244d91a9b6",
+			"revision": "ceefd2213ed29504fff30155163c8f59827734f3",
 			"branch": "master",
 			"path": "internal/utf8internal",
 			"notests": true
@@ -249,7 +249,7 @@
 			"importpath": "golang.org/x/text/language",
 			"repository": "https://go.googlesource.com/text",
 			"vcs": "git",
-			"revision": "d69c40b4be55797923cec7457fac7a244d91a9b6",
+			"revision": "ceefd2213ed29504fff30155163c8f59827734f3",
 			"branch": "master",
 			"path": "language",
 			"notests": true
@@ -258,7 +258,7 @@
 			"importpath": "golang.org/x/text/runes",
 			"repository": "https://go.googlesource.com/text",
 			"vcs": "git",
-			"revision": "d69c40b4be55797923cec7457fac7a244d91a9b6",
+			"revision": "ceefd2213ed29504fff30155163c8f59827734f3",
 			"branch": "master",
 			"path": "runes",
 			"notests": true
@@ -267,7 +267,7 @@
 			"importpath": "golang.org/x/text/transform",
 			"repository": "https://go.googlesource.com/text",
 			"vcs": "git",
-			"revision": "d69c40b4be55797923cec7457fac7a244d91a9b6",
+			"revision": "ceefd2213ed29504fff30155163c8f59827734f3",
 			"branch": "master",
 			"path": "transform",
 			"notests": true
@@ -276,7 +276,7 @@
 			"importpath": "golang.org/x/text/unicode/cldr",
 			"repository": "https://go.googlesource.com/text",
 			"vcs": "git",
-			"revision": "d69c40b4be55797923cec7457fac7a244d91a9b6",
+			"revision": "ceefd2213ed29504fff30155163c8f59827734f3",
 			"branch": "master",
 			"path": "unicode/cldr",
 			"notests": true


### PR DESCRIPTION
This enables a canonical_email for user matching and creation.

It essentially solves the problem of using new authentication providers that may present a given email address inconsistently. i.e. an @gmail.com address may be presented as an @googlemail.com address. Or a user may forget they they once added an user+label@gmail.com and enter a user@gmail.com address.

This set of changes essentially normalises these to produce a single idea of an email address to match. Whatever the original email address was (the first we saw) is the one that notifications is sent to, but the canonical is used for account matching.