### PR TITLE
Batch management of users

### DIFF
--- a/controller/users_batch.go
+++ b/controller/users_batch.go
@@ -1,0 +1,151 @@
+package controller
+
+import (
+	"bytes"
+	"encoding/csv"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/mail"
+	"strconv"
+	"strings"
+
+	"github.com/microcosm-cc/microcosm/models"
+)
+
+// UsersBatchController is a web controller
+type UsersBatchController struct{}
+
+// UsersBatchHandler is a web handler
+func UsersBatchHandler(w http.ResponseWriter, r *http.Request) {
+	c, status, err := models.MakeContext(r, w)
+	if err != nil {
+		c.RespondWithErrorMessage(err.Error(), status)
+		return
+	}
+
+	ctl := UsersBatchController{}
+
+	switch c.GetHTTPMethod() {
+	case "OPTIONS":
+		c.RespondWithOptions([]string{"OPTIONS", "POST"})
+		return
+	case "POST":
+		ctl.Manage(c)
+	default:
+		c.RespondWithStatus(http.StatusMethodNotAllowed)
+		return
+	}
+
+}
+
+func (ctl *UsersBatchController) Manage(c *models.Context) {
+	if !c.Auth.IsSiteOwner {
+		c.RespondWithErrorMessage(
+			"Only a site owner can batch manage users",
+			http.StatusForbidden,
+		)
+		return
+	}
+
+	var ems []models.UserMembership
+
+	switch getContentType(c.Request) {
+	case "application/json":
+		if err := c.Fill(&ems); err != nil {
+			c.RespondWithErrorMessage(
+				fmt.Sprintf("The post data is invalid: %s", err.Error()),
+				http.StatusBadRequest,
+			)
+			return
+		}
+	case "text/csv":
+		dat, err := ioutil.ReadAll(c.Request.Body)
+		if err != nil {
+			c.RespondWithErrorMessage(
+				fmt.Sprintf("The CSV could not be read from the request: %s", err.Error()),
+				http.StatusBadRequest,
+			)
+			return
+		}
+
+		data := string(dat)
+		data = strings.Replace(data, "\r\n", "\n", -1)
+		data = strings.Replace(data, "\r", "\n", -1)
+
+		reader := csv.NewReader(bytes.NewBufferString(data))
+
+		rows, err := reader.ReadAll()
+		if err != nil {
+			c.RespondWithErrorMessage(
+				fmt.Sprintf("That was not a CSV file: %s", err.Error()),
+				http.StatusBadRequest,
+			)
+			return
+		}
+
+		for _, row := range rows {
+			if len(row) < 2 {
+				c.RespondWithErrorMessage(
+					"Each line in the CSV file must have at least 2 fields: email,integer",
+					http.StatusBadRequest,
+				)
+				return
+			}
+
+			if row[0] == "" || row[1] == "" {
+				continue
+			}
+
+			email, err := mail.ParseAddress(row[0])
+			if err != nil {
+				c.RespondWithErrorMessage(err.Error(), http.StatusBadRequest)
+				return
+			}
+
+			isMember, err := strconv.ParseBool(row[1])
+			if err != nil {
+				c.RespondWithErrorMessage(err.Error(), http.StatusBadRequest)
+				return
+			}
+
+			var m models.UserMembership
+			m.Email = email.Address
+			m.IsMember = isMember
+
+			ems = append(ems, m)
+		}
+	default:
+		c.RespondWithErrorMessage(
+			"Only application/json or text/csv can be POST'd",
+			http.StatusBadRequest,
+		)
+		return
+	}
+
+	if len(ems) == 0 {
+		c.RespondWithErrorMessage(
+			"Input empty, no rows to process",
+			http.StatusBadRequest,
+		)
+		return
+	}
+
+	status, err := models.ManageUsers(c.Site, ems)
+	if err != nil {
+		c.RespondWithErrorMessage(err.Error(), status)
+		return
+	}
+
+	c.RespondWithOK()
+}
+
+func getContentType(r *http.Request) string {
+	ct := r.Header.Get("Content-Type")
+	if strings.TrimSpace(ct) == "" {
+		return "application/x-www-form-urlencoded"
+	}
+
+	// Ignore anything after a ; (like charset) and return the content-type
+	return strings.ToLower(strings.Split(ct, ";")[0])
+}

--- a/controller/users_batch.go
+++ b/controller/users_batch.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/golang/glog"
 	"github.com/microcosm-cc/microcosm/models"
 )
 
@@ -39,6 +40,7 @@ func UsersBatchHandler(w http.ResponseWriter, r *http.Request) {
 
 }
 
+// Manage allows the management of users by a site admin
 func (ctl *UsersBatchController) Manage(c *models.Context) {
 	if !c.Auth.IsSiteOwner {
 		c.RespondWithErrorMessage(
@@ -72,6 +74,8 @@ func (ctl *UsersBatchController) Manage(c *models.Context) {
 		data := string(dat)
 		data = strings.Replace(data, "\r\n", "\n", -1)
 		data = strings.Replace(data, "\r", "\n", -1)
+
+		glog.Warningf("CSV received: %s", data)
 
 		reader := csv.NewReader(bytes.NewBufferString(data))
 

--- a/helpers/db.go
+++ b/helpers/db.go
@@ -72,3 +72,11 @@ func GetTransaction() (*sql.Tx, error) {
 
 	return tx, err
 }
+
+// Er provides an interface that both sql.DB and sql.Tx fulfil, allowing for
+// generic funcs that either can use.
+type Er interface {
+	Exec(query string, args ...interface{}) (sql.Result, error)
+	Query(query string, args ...interface{}) (*sql.Rows, error)
+	QueryRow(query string, args ...interface{}) *sql.Row
+}

--- a/models/profiles.go
+++ b/models/profiles.go
@@ -1128,7 +1128,7 @@ SELECT profile_id
 		&profileID,
 	)
 	if err == sql.ErrNoRows {
-		glog.Warning(err)
+		glog.Info(err)
 		return profileID, http.StatusNotFound,
 			fmt.Errorf(
 				"Profile for site (%d) and user (%d) not found.",

--- a/models/users.go
+++ b/models/users.go
@@ -36,7 +36,7 @@ type UserType struct {
 	Meta h.CoreMetaType `json:"meta"`
 }
 
-// UserMembership
+// UserMembership is for managing user permissions
 type UserMembership struct {
 	Email    string `json:"email"`
 	IsMember bool   `json:"isMember"`

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -149,6 +149,7 @@ var (
 
 		"/api/v1/users":                  controller.UsersHandler,
 		"/api/v1/users/{user_id:[0-9]+}": controller.UserHandler,
+		"/api/v1/users/batch":            controller.UsersBatchHandler,
 
 		"/api/v1/watchers":                     controller.WatchersHandler,
 		"/api/v1/watchers/{watcher_id:[0-9]+}": controller.WatcherHandler,


### PR DESCRIPTION
Provides a way to upload a CSV file of JSON file that describes a set of email addresses to create and whether or not to grant them permission to inner parts of the site reserved for members.

This endpoint can only be called using the credentials of the site administrator.

The CSV is expected to be two columns per line, the email of the user and a boolean 1 or 0 indicating whether the members privilege should be granted.

```csv
test@example.org,1
test2@example.org,0
```

The JSON is a simple object array:

```javascript
[
  {"email":"test@example.org", "isMember":true},
  {"email":"test2@example.org", "isMember":false}
]
```

That file can then be uploaded to the API endpoint for your site, for example:

```bash
curl -X POST \
	-H "Content-Type: text/csv" \
	--data-binary @Members.csv \
	"https://yoursite.microco.sm/api/v1/users/batch?access_token=yourAccessToken"
```

This should be good for managing thousands of users at a time.

Note 1: If the file gets too big to upload, split it across multiple smaller files.

Note 2: Creating users involves creating an avatar and storing that in AWS S3, so expect lots of new users to take longer than lots of permission changes.